### PR TITLE
Fix intake flow and Supabase persistence

### DIFF
--- a/components/IntakeForm.jsx
+++ b/components/IntakeForm.jsx
@@ -168,7 +168,7 @@ export function IntakeForm() {
       const payload = await response.json()
       setSubmission(payload.submission)
       setForm(defaultForm)
-      setStep(0)
+      setStep(sections.length - 1)
       setStepErrors({})
       setShowSuccess(true)
     } catch (err) {

--- a/lib/submission-store.js
+++ b/lib/submission-store.js
@@ -5,7 +5,7 @@ import { createServiceSupabaseClient } from '@lib/supabase'
 const SUBMISSION_STATUS = new Set(['pending', 'accepted', 'rejected'])
 
 const memoryStore = {
-  submissions: [],
+  submissions: []
 }
 
 let supabaseHealthy = true
@@ -27,61 +27,205 @@ function getSupabaseClient() {
   }
 }
 
+function stringOrNull(value) {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : null
+}
+
+function normalizeDateish(value) {
+  if (!value) return null
+  if (value instanceof Date) {
+    const timestamp = value.getTime()
+    return Number.isNaN(timestamp) ? null : value.toISOString()
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    const parsed = new Date(trimmed)
+    if (Number.isNaN(parsed.getTime())) {
+      return trimmed
+    }
+    return trimmed.length === 10 ? trimmed : parsed.toISOString()
+  }
+  return null
+}
+
+function toIsoDate(value) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+  return date.toISOString()
+}
+
+function sanitizeReferences(value) {
+  if (!Array.isArray(value)) return []
+
+  return value
+    .map((item, index) => {
+      if (!item) return null
+
+      if (typeof item === 'string') {
+        const url = item.trim()
+        if (!url) return null
+        return { url, name: `Reference ${index + 1}` }
+      }
+
+      if (typeof item === 'object') {
+        const rawUrl = typeof item.url === 'string' ? item.url.trim() : ''
+        if (!rawUrl) return null
+        const label =
+          (typeof item.name === 'string' && item.name.trim()) ||
+          (typeof item.title === 'string' && item.title.trim()) ||
+          rawUrl
+        return { url: rawUrl, name: label }
+      }
+
+      return null
+    })
+    .filter(Boolean)
+}
+
+function sanitizeMetadata(input = {}) {
+  const metadata = {
+    clientName: stringOrNull(input.clientName) ?? null,
+    company: stringOrNull(input.company) ?? null,
+    phone: stringOrNull(input.phone) ?? null,
+    projectTitle: stringOrNull(input.projectTitle) ?? null,
+    projectType: stringOrNull(input.projectType) ?? null,
+    timeline: stringOrNull(input.timeline) ?? null,
+    budget: stringOrNull(input.budget) ?? null,
+    keyMoment: normalizeDateish(input.keyMoment),
+    additionalNotes: stringOrNull(input.additionalNotes) ?? null,
+    referralSource: stringOrNull(input.referralSource) ?? null,
+    references: sanitizeReferences(input.references)
+  }
+
+  return metadata
+}
+
 function mapProject(row) {
   if (!row) return null
 
   const brief = Array.isArray(row.briefs) && row.briefs.length > 0 ? row.briefs[0] : null
   const scope = (brief && typeof brief.scope === 'object' && brief.scope) || {}
-  const references = Array.isArray(scope.references)
-    ? scope.references.filter((item) => item && typeof item === 'object')
-    : []
+  const metadata = sanitizeMetadata({
+    ...scope,
+    projectTitle: scope.projectTitle ?? row.project_title ?? row.title ?? null,
+    projectType: scope.projectType ?? row.type ?? null,
+    keyMoment: row.key_moment ?? scope.keyMoment ?? row.due_date ?? null,
+    references: scope.references ?? []
+  })
+
+  const name = metadata.projectTitle ?? row.title ?? 'Untitled engagement'
+  const email = row.owner_email ?? scope.email ?? null
 
   return {
     id: row.id,
-    name: row.project_title ?? row.title ?? 'Untitled engagement',
-    email: row.owner_email ?? scope.email ?? null,
+    projectId: row.id,
+    name,
+    email,
     status: row.status ?? 'pending',
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
+    createdAt: row.created_at ?? null,
+    updatedAt: row.updated_at ?? null,
     details: brief?.summary ?? row.details ?? '',
     metadata: {
-      clientName: scope.clientName ?? null,
-      company: scope.company ?? null,
-      phone: scope.phone ?? null,
-      projectTitle: scope.projectTitle ?? row.project_title ?? row.title ?? null,
-      projectType: scope.projectType ?? row.type ?? null,
-      timeline: scope.timeline ?? null,
-      budget: scope.budget ?? null,
-      keyMoment: row.key_moment ?? scope.keyMoment ?? row.due_date ?? null,
-      additionalNotes: scope.additionalNotes ?? null,
-      referralSource: scope.referralSource ?? null,
-      references,
-    },
+      ...metadata,
+      projectTitle: metadata.projectTitle ?? name,
+      email: email ?? null
+    }
   }
+}
+
+function mapSubmissionRow(row) {
+  if (!row) return null
+
+  const metadata = sanitizeMetadata(row.metadata ?? {})
+  const projectId = row.project_id ?? row.id ?? null
+  const name = metadata.projectTitle ?? row.name ?? 'Untitled engagement'
+  const email = row.email ?? metadata.email ?? null
+
+  return {
+    id: projectId ?? row.id,
+    projectId,
+    name,
+    email,
+    status: row.status ?? 'pending',
+    createdAt: row.created_at ?? null,
+    updatedAt: row.updated_at ?? null,
+    details: row.details ?? '',
+    metadata: {
+      ...metadata,
+      projectTitle: metadata.projectTitle ?? name
+    }
+  }
+}
+
+function isMissingRelationError(error) {
+  if (!error) return false
+  if (error.code === '42P01' || error.code === 'PGRST204' || error.code === 'PGRST201' || error.code === 'PGRST205') {
+    return true
+  }
+  const message = `${error.message ?? ''} ${error.details ?? ''}`.toLowerCase()
+  return message.includes('does not exist') || message.includes('missing') || message.includes('relation')
+}
+
+async function listProjectsFallback(supabase) {
+  const { data, error } = await supabase
+    .from('projects')
+    .select(
+      `id, title, owner_email, status, type, due_date, created_at, updated_at,
+       briefs(summary, scope)`
+    )
+    .in('status', ['pending', 'accepted', 'rejected'])
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('Failed to list submissions from projects', error)
+    return []
+  }
+
+  return (data ?? []).map((row) => mapProject({ ...row, key_moment: row.due_date }))
+}
+
+async function loadSubmissionFromProjects(supabase, projectId) {
+  const { data, error } = await supabase
+    .from('projects')
+    .select('id, title, owner_email, status, type, due_date, created_at, updated_at, briefs(summary, scope)')
+    .eq('id', projectId)
+    .maybeSingle()
+
+  if (error) {
+    if (!isMissingRelationError(error)) {
+      console.error('Failed to load submission from projects', error)
+    }
+    return null
+  }
+
+  if (!data) return null
+  return mapProject({ ...data, key_moment: data?.due_date })
 }
 
 export async function listSubmissions() {
   const supabase = getSupabaseClient()
   if (supabase) {
     const { data, error } = await supabase
-      .from('projects')
-      .select(
-        `id, title, owner_email, status, type, due_date, created_at, updated_at,
-         briefs(summary, scope)`
-      )
-      .in('status', ['pending', 'accepted', 'rejected'])
+      .from('intake_submissions')
+      .select('*')
       .order('created_at', { ascending: false })
 
     if (!error) {
-      return (data ?? []).map((row) => mapProject({ ...row, key_moment: row.due_date }))
+      return (data ?? []).map((row) => mapSubmissionRow(row))
     }
 
-    if (error?.code === 'PGRST205') {
-      markSupabaseFailure(error)
-    } else {
-      console.error('Failed to list submissions', error)
-      return []
+    if (isMissingRelationError(error)) {
+      return listProjectsFallback(supabase)
     }
+
+    console.error('Failed to list intake submissions', error)
+    return []
   }
 
   return [...memoryStore.submissions]
@@ -91,23 +235,25 @@ export async function findSubmission(id) {
   const supabase = getSupabaseClient()
   if (supabase) {
     const { data, error } = await supabase
-      .from('projects')
-      .select(`id, title, owner_email, status, type, due_date, created_at, updated_at, briefs(summary, scope)`)
+      .from('intake_submissions')
+      .select('*')
       .eq('id', id)
-      .single()
+      .maybeSingle()
 
     if (!error) {
-      return mapProject({ ...data, key_moment: data?.due_date })
+      return mapSubmissionRow(data)
     }
 
-    if (error?.code === 'PGRST205') {
-      markSupabaseFailure(error)
-    } else if (error?.code === 'PGRST116' || error?.details?.includes('Results contain 0 rows')) {
-      return null
-    } else {
-      console.error('Failed to find submission', error)
+    if (isMissingRelationError(error)) {
+      return loadSubmissionFromProjects(supabase, id)
+    }
+
+    if (error?.code === 'PGRST116' || error?.details?.includes('Results contain 0 rows')) {
       return null
     }
+
+    console.error('Failed to find submission', error)
+    return null
   }
 
   return memoryStore.submissions.find((item) => item.id === id) ?? null
@@ -115,12 +261,30 @@ export async function findSubmission(id) {
 
 export async function createSubmission(input) {
   const supabase = getSupabaseClient()
+  const sanitizedMetadata = sanitizeMetadata({
+    clientName: input.clientName,
+    company: input.company,
+    phone: input.phone,
+    projectTitle: input.projectTitle ?? input.name ?? null,
+    projectType: input.projectType ?? input.categoryHint ?? null,
+    timeline: input.timeline,
+    budget: input.budget,
+    keyMoment: input.keyMoment ?? input.dueDate ?? null,
+    additionalNotes: input.additionalNotes,
+    referralSource: input.referralSource,
+    references: input.references
+  })
+
+  const projectTitle = sanitizedMetadata.projectTitle ?? input.projectTitle ?? input.name ?? 'Untitled engagement'
+  const projectType = sanitizedMetadata.projectType ?? input.projectType ?? input.categoryHint ?? 'intake'
+  const summary = input.projectDescription ?? input.details ?? ''
+  const dueDateIso = sanitizedMetadata.keyMoment ? toIsoDate(sanitizedMetadata.keyMoment) : null
+
+  sanitizedMetadata.projectTitle = projectTitle
+  sanitizedMetadata.projectType = projectType
+
   if (supabase) {
     const projectId = randomUUID()
-
-    const projectTitle = input.projectTitle || input.name || 'Untitled engagement'
-    const projectType = input.projectType || 'intake'
-    const keyMoment = input.keyMoment ? new Date(input.keyMoment).toISOString() : null
 
     const { error: projectError } = await supabase.from('projects').insert({
       id: projectId,
@@ -128,40 +292,29 @@ export async function createSubmission(input) {
       owner_email: input.email,
       status: 'pending',
       type: projectType,
-      due_date: keyMoment,
-      priority: 3,
+      due_date: dueDateIso,
+      priority: 3
     })
 
     if (projectError) {
-      if (projectError.code === 'PGRST205') {
+      if (isMissingRelationError(projectError)) {
+        console.warn('Projects table unavailable; storing submission in memory.', projectError.message)
         markSupabaseFailure(projectError)
       } else {
         console.error('Failed to insert project', projectError)
         throw projectError
       }
     } else {
-      const scope = {
-        clientName: input.clientName ?? null,
-        company: input.company ?? null,
-        email: input.email ?? null,
-        phone: input.phone ?? null,
-        projectTitle,
-        projectType,
-        timeline: input.timeline ?? null,
-        budget: input.budget ?? null,
-        keyMoment,
-        additionalNotes: input.additionalNotes ?? null,
-        referralSource: input.referralSource ?? null,
-        references: input.references ?? [],
-      }
-
       const { error: briefError } = await supabase.from('briefs').insert({
         id: randomUUID(),
         project_id: projectId,
-        summary: input.projectDescription ?? input.details ?? '',
-        scope,
+        summary,
+        scope: {
+          ...sanitizedMetadata,
+          email: input.email ?? null
+        },
         constraints: {},
-        success_criteria: {},
+        success_criteria: {}
       })
 
       if (briefError) {
@@ -169,32 +322,44 @@ export async function createSubmission(input) {
         throw briefError
       }
 
-      return findSubmission(projectId)
+      const { data: submissionRow, error: submissionError } = await supabase
+        .from('intake_submissions')
+        .insert({
+          id: projectId,
+          project_id: projectId,
+          name: projectTitle,
+          email: input.email,
+          status: 'pending',
+          details: summary,
+          metadata: sanitizedMetadata
+        })
+        .select()
+        .single()
+
+      if (submissionError) {
+        if (isMissingRelationError(submissionError)) {
+          console.warn('intake_submissions table unavailable; falling back to projects view.', submissionError.message)
+          return loadSubmissionFromProjects(supabase, projectId)
+        }
+
+        console.error('Failed to insert intake submission', submissionError)
+        throw submissionError
+      }
+
+      return mapSubmissionRow(submissionRow)
     }
   }
 
   const now = new Date().toISOString()
   const record = {
     id: randomUUID(),
-    name: input.projectTitle || input.name || 'Untitled engagement',
+    name: projectTitle,
     email: input.email,
     status: 'pending',
     createdAt: now,
     updatedAt: now,
-    details: input.projectDescription ?? input.details ?? '',
-    metadata: {
-      clientName: input.clientName ?? null,
-      company: input.company ?? null,
-      phone: input.phone ?? null,
-      projectTitle: input.projectTitle ?? input.name ?? null,
-      projectType: input.projectType ?? 'intake',
-      timeline: input.timeline ?? null,
-      budget: input.budget ?? null,
-      keyMoment: input.keyMoment ?? null,
-      additionalNotes: input.additionalNotes ?? null,
-      referralSource: input.referralSource ?? null,
-      references: input.references ?? [],
-    },
+    details: summary,
+    metadata: sanitizedMetadata
   }
 
   memoryStore.submissions.unshift(record)
@@ -211,10 +376,19 @@ export async function updateSubmissionStatus(id, status) {
     const { error } = await supabase.from('projects').update({ status }).eq('id', id)
 
     if (!error) {
+      const { error: syncError } = await supabase
+        .from('intake_submissions')
+        .update({ status, updated_at: new Date().toISOString() })
+        .eq('id', id)
+
+      if (syncError && !isMissingRelationError(syncError)) {
+        console.error('Failed to sync intake submission status', syncError)
+      }
+
       return findSubmission(id)
     }
 
-    if (error.code === 'PGRST205') {
+    if (isMissingRelationError(error)) {
       markSupabaseFailure(error)
     } else {
       console.error('Failed to update submission status', error)

--- a/supabase/migrations/0002_intake_submissions.sql
+++ b/supabase/migrations/0002_intake_submissions.sql
@@ -1,0 +1,39 @@
+create table if not exists intake_submissions (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid references projects(id) on delete set null,
+  name text not null,
+  email text not null,
+  status text not null default 'pending',
+  details text default '',
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists intake_submissions_status_idx on intake_submissions(status);
+create index if not exists intake_submissions_created_at_idx on intake_submissions(created_at desc);
+
+create or replace function update_intake_submissions_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists set_intake_submissions_updated_at on intake_submissions;
+create trigger set_intake_submissions_updated_at
+before update on intake_submissions
+for each row
+execute function update_intake_submissions_updated_at();
+
+alter table intake_submissions enable row level security;
+
+create policy "Intake submissions are readable" on intake_submissions
+  for select
+  using (true);
+
+create policy "Service role can write intake submissions" on intake_submissions
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- keep the intake wizard on the final step after a successful submit so the flow no longer snaps back to step 1
- refactor the submission store to normalise metadata, write to the new `intake_submissions` table, and fall back gracefully when tables are missing
- add a Supabase migration that creates the `intake_submissions` table, indexes, trigger, and policies for service-role writes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d66a6132708333b755ae5456c9c9ac