### PR TITLE
Fix team redirect after sign-in

### DIFF
--- a/lib/auth-utils.js
+++ b/lib/auth-utils.js
@@ -5,10 +5,25 @@ export function parseList(value) {
     .filter(Boolean)
 }
 
+function readEnvValue(...keys) {
+  for (const key of keys) {
+    const value = process.env?.[key]
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value
+    }
+  }
+  return null
+}
+
 export function isAllowedEmail(email) {
   const em = (email || '').toLowerCase()
-  const allowlist = parseList(process.env.TEAM_EMAIL_ALLOWLIST)
-  const domains = parseList(process.env.TEAM_EMAIL_DOMAINS || 'glassbox.com,glassbox.studio')
+  const allowlist = parseList(
+    readEnvValue('TEAM_EMAIL_ALLOWLIST', 'NEXT_PUBLIC_TEAM_EMAIL_ALLOWLIST')
+  )
+  const domains = parseList(
+    readEnvValue('TEAM_EMAIL_DOMAINS', 'NEXT_PUBLIC_TEAM_EMAIL_DOMAINS') ||
+      'glassbox.com,glassbox.studio'
+  )
 
   if (allowlist.length && allowlist.includes(em)) return true
   if (domains.length && domains.some((d) => em.endsWith(`@${d}`))) return true


### PR DESCRIPTION
## Summary
- determine the signed-in user role immediately using Supabase session data and shared allowlist logic
- fall back to the whoami API only when the email is unavailable so team members are redirected to /dashboard without delay
- share allowlist configuration between server and client by reading NEXT_PUBLIC overrides

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d6980d33448333a57c660f4ce1eed7