### PR TITLE
Fix email allowlist env lookup for edge runtimes

### DIFF
--- a/lib/auth-utils.js
+++ b/lib/auth-utils.js
@@ -5,10 +5,17 @@ export function parseList(value) {
     .filter(Boolean)
 }
 
+function getEnvValue(key) {
+  if (typeof process !== 'undefined' && process?.env) {
+    return process.env[key]
+  }
+  return undefined
+}
+
 export function isAllowedEmail(email) {
   const em = (email || '').toLowerCase()
-  const allowlist = parseList(process.env.TEAM_EMAIL_ALLOWLIST)
-  const domains = parseList(process.env.TEAM_EMAIL_DOMAINS || 'glassbox.com,glassbox.studio')
+  const allowlist = parseList(getEnvValue('TEAM_EMAIL_ALLOWLIST'))
+  const domains = parseList(getEnvValue('TEAM_EMAIL_DOMAINS') || 'glassbox.com,glassbox.studio')
 
   if (allowlist.length && allowlist.includes(em)) return true
   if (domains.length && domains.some((d) => em.endsWith(`@${d}`))) return true


### PR DESCRIPTION
## Summary
- guard email allowlist helper against missing `process` to avoid client/runtime errors

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d69a62d7d88333a38a8d0aab5d2437