### PR TITLE
Fix sign-in redirect loop for unauthorized users

### DIFF
--- a/components/SignInForm.jsx
+++ b/components/SignInForm.jsx
@@ -135,13 +135,28 @@ export function SignInForm() {
 }
 
 function resolveDestination(isTeam) {
+  const fallback = isTeam ? '/dashboard' : '/my'
+
   try {
     const url = new URL(window.location.href)
     const next = url.searchParams.get('next')
-    if (next) {
+    if (typeof next === 'string' && isAllowedNext(next, isTeam)) {
       return next
     }
   } catch {}
 
-  return isTeam ? '/dashboard' : '/'
+  return fallback
+}
+
+function isAllowedNext(next, isTeam) {
+  if (!next || !next.startsWith('/') || next.startsWith('//')) {
+    return false
+  }
+
+  if (isTeam) {
+    return true
+  }
+
+  const teamOnlyPrefixes = ['/dashboard', '/projects', '/tasks', '/new']
+  return !teamOnlyPrefixes.some((prefix) => next.startsWith(prefix))
 }


### PR DESCRIPTION
## Summary
- guard the sign-in redirect logic against protected destinations when a non-team user signs in
- default non-team users to the my workspace after OTP verification to avoid bouncing back to the sign-in page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d69c17b70c8333915cdeab9b8122b0