### PR TITLE
Ensure Supabase OTP login persists server sessions

### DIFF
--- a/app/api/auth/session/route.js
+++ b/app/api/auth/session/route.js
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: 'lax',
+  secure: process.env.NODE_ENV === 'production',
+  path: '/'
+}
+
+function tokenMaxAge(expiresAt) {
+  if (typeof expiresAt !== 'number') return undefined
+  const nowInSeconds = Math.floor(Date.now() / 1000)
+  const secondsUntilExpiry = Math.max(0, Math.floor(expiresAt - nowInSeconds))
+  return secondsUntilExpiry || 60 * 5
+}
+
+export async function POST(request) {
+  const { accessToken, refreshToken, expiresAt } = await request.json().catch(() => ({}))
+
+  if (!accessToken || !refreshToken || !expiresAt) {
+    return NextResponse.json({ error: 'Missing session tokens' }, { status: 400 })
+  }
+
+  const response = NextResponse.json({ ok: true })
+  response.cookies.set('sb-access-token', accessToken, {
+    ...COOKIE_OPTIONS,
+    maxAge: tokenMaxAge(expiresAt)
+  })
+  response.cookies.set('sb-refresh-token', refreshToken, {
+    ...COOKIE_OPTIONS,
+    maxAge: 60 * 60 * 24 * 30
+  })
+
+  return response
+}
+
+export async function DELETE() {
+  const response = NextResponse.json({ ok: true })
+  response.cookies.set('sb-access-token', '', {
+    ...COOKIE_OPTIONS,
+    maxAge: 0
+  })
+  response.cookies.set('sb-refresh-token', '', {
+    ...COOKIE_OPTIONS,
+    maxAge: 0
+  })
+
+  return response
+}
+

--- a/components/AuthButtons.jsx
+++ b/components/AuthButtons.jsx
@@ -44,6 +44,7 @@ function AuthButtons() {
   async function signOut() {
     const supabase = createBrowserSupabaseClient()
     await supabase.auth.signOut()
+    await fetch('/api/auth/session', { method: 'DELETE' })
     window.location.assign('/')
   }
 

--- a/components/SignInForm.jsx
+++ b/components/SignInForm.jsx
@@ -50,12 +50,30 @@ export function SignInForm() {
     setLoading(true)
     try {
       const supabase = createBrowserSupabaseClient()
-      const { error } = await supabase.auth.verifyOtp({
+      const { data, error } = await supabase.auth.verifyOtp({
         email: email.trim(),
         token: code.trim(),
         type: 'email'
       })
       if (error) throw error
+      const session = data?.session
+      if (!session?.access_token || !session?.refresh_token || !session?.expires_at) {
+        throw new Error('Unable to establish a session. Please request a new code and try again.')
+      }
+      const sync = await fetch('/api/auth/session', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          accessToken: session.access_token,
+          refreshToken: session.refresh_token,
+          expiresAt: session.expires_at
+        })
+      })
+      if (!sync.ok) {
+        throw new Error('Failed to persist sign-in. Please try again.')
+      }
       // Determine role and destination
       const res = await fetch('/api/auth/whoami', { cache: 'no-store' })
       const who = await res.json().catch(() => ({ isTeam: false }))


### PR DESCRIPTION
## Summary
- add a dynamic API route that stores Supabase access and refresh tokens in secure cookies and clears them on sign-out
- sync the OTP verification flow with the new session route so server components can detect the signed-in user
- clear the persisted auth cookies when signing out from the client UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d6a090912c83338a4ba4b2b6729404