### PR TITLE
Fix Supabase session persistence for dashboard access

### DIFF
--- a/lib/supabase-browser.js
+++ b/lib/supabase-browser.js
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js'
+import { createBrowserClient } from '@supabase/ssr'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
@@ -8,9 +8,10 @@ export function createBrowserSupabaseClient() {
     throw new Error('Supabase browser client requires NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY')
   }
 
-  return createClient(supabaseUrl, anonKey, {
+  return createBrowserClient(supabaseUrl, anonKey, {
     auth: {
-      persistSession: true
+      persistSession: true,
+      detectSessionInUrl: true
     }
   })
 }

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import { createServerClient } from '@supabase/ssr'
 import { headers, cookies } from 'next/headers'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -46,21 +47,21 @@ export function createServerSupabaseClient() {
   const cookieStore = cookies()
   const headerList = headers()
 
-  return createClient(supabaseUrl, anonKey, {
-    global: {
-      headers: {
-        'X-Client-Info': 'project-ops-microsite/0.1.0',
-        'X-Forwarded-For': headerList.get('x-forwarded-for') ?? undefined
-      }
-    },
-    auth: {
-      persistSession: false
-    },
+  return createServerClient(supabaseUrl, anonKey, {
     cookies: {
       get(name) {
-        const cookie = cookieStore.get(name)
-        return cookie ? cookie.value : undefined
+        return cookieStore.get(name)?.value
+      },
+      set() {
+        // Cookies are read-only in Next.js Server Components, so we provide a noop setter.
+      },
+      remove() {
+        // Noop remover for the same reason as set().
       }
+    },
+    headers: {
+      'X-Client-Info': 'project-ops-microsite/0.1.0',
+      'X-Forwarded-For': headerList.get('x-forwarded-for') ?? undefined
     }
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^1.7.18",
         "@heroicons/react": "^2.0.18",
+        "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.43.1",
         "@tanstack/react-query": "^5.51.1",
         "@vercel/sdk": "^1.11.4",
@@ -1637,6 +1638,18 @@
         "@types/phoenix": "^1.6.6",
         "@types/ws": "^8.18.1",
         "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.7.0.tgz",
+      "integrity": "sha512-G65t5EhLSJ5c8hTCcXifSL9Q/ZRXvqgXeNo+d3P56f4U1IxwTqjB64UfmfixvmMcjuxnq2yGqEWVJqUcO+AzAg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.43.4"
       }
     },
     "node_modules/@supabase/storage-js": {
@@ -3991,6 +4004,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/create-require": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@headlessui/react": "^1.7.18",
     "@heroicons/react": "^2.0.18",
     "@supabase/supabase-js": "^2.43.1",
+    "@supabase/ssr": "^0.7.0",
     "@tanstack/react-query": "^5.51.1",
     "@vercel/sdk": "^1.11.4",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- add the Supabase SSR helper dependency so client logins persist to cookies
- use the SSR browser and server clients to share auth state and respect protected redirects

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d6a34f66b08333a17e1998a9ffe695