### PR TITLE
Adjust client sign-in flow and improve dropdown contrast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,6 +46,11 @@
   textarea,
   select {
     @apply rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-100 shadow-inner transition duration-200 placeholder:text-slate-500 focus:border-white/35 focus:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/25;
+    color-scheme: dark;
+  }
+
+  select option {
+    @apply bg-slate-900 text-slate-100;
   }
 }
 

--- a/app/my/[id]/page.jsx
+++ b/app/my/[id]/page.jsx
@@ -12,7 +12,7 @@ export default async function MyProjectDetailsPage({ params }) {
   const { data } = await supabase.auth.getUser()
   const user = data?.user ?? null
   if (!user?.email) {
-    redirect(`/sign-in?next=/my/${params.id}`)
+    redirect(`/sign-in?audience=client&next=/my/${params.id}`)
   }
 
   const submission = await findSubmission(params.id)

--- a/app/my/page.jsx
+++ b/app/my/page.jsx
@@ -11,7 +11,7 @@ export default async function MyProjectsPage() {
   const { data } = await supabase.auth.getUser()
   const user = data?.user ?? null
   if (!user?.email) {
-    redirect('/sign-in?next=/my')
+    redirect('/sign-in?audience=client&next=/my')
   }
 
   const submissions = await listSubmissionsByEmail(user.email)

--- a/app/sign-in/page.jsx
+++ b/app/sign-in/page.jsx
@@ -2,15 +2,23 @@ import { SignInForm } from '@components/SignInForm'
 
 export const dynamic = 'force-dynamic'
 
-export default function SignInPage() {
+function normalizeAudience(raw) {
+  const value = typeof raw === 'string' ? raw.toLowerCase() : ''
+  return value === 'team' || value === 'admin' || value === 'internal' ? 'team' : 'client'
+}
+
+export default function SignInPage({ searchParams }) {
+  const audience = normalizeAudience(searchParams?.audience)
+  const badgeText = audience === 'team' ? 'Glassbox team access' : 'Client workspace access'
+
   return (
     <div className="space-y-8">
       <header className="text-center">
         <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-white/70">
-          Glassbox team access
+          {badgeText}
         </span>
       </header>
-      <SignInForm />
+      <SignInForm audience={audience} />
     </div>
   )
 }

--- a/components/AuthButtons.jsx
+++ b/components/AuthButtons.jsx
@@ -68,7 +68,7 @@ function AuthButtons() {
         </>
       ) : (
         <Link
-          href="/sign-in"
+          href="/sign-in?audience=client"
           className="rounded-full border border-white/15 bg-white/90 px-4 py-1 font-semibold text-[#111216] hover:bg-white"
         >
           Sign in

--- a/components/IntakeForm.jsx
+++ b/components/IntakeForm.jsx
@@ -48,7 +48,7 @@ export function IntakeForm() {
   const [showSuccess, setShowSuccess] = useState(false)
   const [authRequired, setAuthRequired] = useState(false)
   const [draftReady, setDraftReady] = useState(false)
-  const [signInHref, setSignInHref] = useState('/sign-in?next=/')
+  const [signInHref, setSignInHref] = useState('/sign-in?audience=client&next=%2F')
 
   const sections = useMemo(
     () => [
@@ -74,7 +74,7 @@ export function IntakeForm() {
   useEffect(() => {
     if (typeof window === 'undefined') return
     const next = `${window.location.pathname}${window.location.search}${window.location.hash}` || '/'
-    setSignInHref(`/sign-in?next=${encodeURIComponent(next)}`)
+    setSignInHref(`/sign-in?audience=client&next=${encodeURIComponent(next)}`)
   }, [])
 
   useEffect(() => {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -10,11 +10,13 @@ export async function requireTeamUser(nextPath = '/my') {
   const user = data?.user ?? null
 
   if (error || !user) {
-    redirect(`/sign-in?next=${encodeURIComponent(nextPath)}`)
+    const params = new URLSearchParams({ audience: 'team', next: nextPath })
+    redirect(`/sign-in?${params.toString()}`)
   }
 
   if (!isAllowedEmail(user.email)) {
-    redirect(`/sign-in?error=unauthorized&next=${encodeURIComponent(nextPath)}`)
+    const params = new URLSearchParams({ audience: 'team', error: 'unauthorized', next: nextPath })
+    redirect(`/sign-in?${params.toString()}`)
   }
 
   return user


### PR DESCRIPTION
## Summary
- Differentiate client and team sign-in flows with an audience selector and tailored messaging.
- Update marketing and workspace redirects to send clients to the correct sign-in experience while preserving team-only gating.
- Improve select element styling so dropdown options render with higher contrast against the dark theme.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68db88c7c24483339b96b80b7a1900ae