### PR TITLE
Rebuild campaign intake for new campaign questionnaire

### DIFF
--- a/components/IntakeForm.jsx
+++ b/components/IntakeForm.jsx
@@ -5,38 +5,124 @@ import Link from 'next/link'
 import { cloneElement, isValidElement, useEffect, useMemo, useState } from 'react'
 
 const defaultForm = {
-  clientName: '',
-  company: '',
-  email: '',
-  phone: '',
-  projectTitle: '',
-  projectType: '',
-  timeline: '',
+  objectives: [],
+  objectiveOther: '',
+  campaignType: '',
+  campaignTypeOther: '',
+  demographics: '',
+  psychographics: '',
+  problemsSolved: '',
+  painPoints: '',
+  audienceTarget: '',
+  personasFiles: [],
+  audienceThinkFeel: '',
+  audienceThinkFeelSecondary: '',
+  deliverables: [],
+  deliverablesOther: '',
+  brandTone: [],
+  brandToneOther: '',
+  referenceCampaigns: [],
+  ctaFocus: '',
+  ctaOther: '',
+  mandatoryAssets: [],
+  brandGuidelines: [],
+  packShots: [],
   budget: '',
-  projectDescription: '',
-  keyMoment: '',
-  references: '',
-  additionalNotes: '',
-  referralSource: ''
+  goLiveDate: '',
+  successMetrics: [],
+  successMetricsOther: '',
+  generalNotes: ''
 }
 
-const guidance = [
-  'Share the business inflection point and what success looks like when this launches.',
-  'Flag critical market windows, priority channels, and executives joining approvals.',
-  'Link brand systems, research, or inspiration decks so we calibrate tone instantly.'
+const objectiveOptions = [
+  'Increase Brand Awareness',
+  'Generate Leads',
+  'Drive Website Traffic',
+  'Boost Conversions',
+  'Grow Social Media Engagement',
+  'Promote a New Product or Service',
+  'Strengthen Customer Loyalty / Retention',
+  'Other'
 ]
 
-const projectTypes = [
-  'Brand identity',
-  'Campaign',
-  'Digital product',
-  'Spatial / retail',
-  'Launch strategy'
+const campaignTypeOptions = [
+  'Product Launch',
+  'Seasonal Campaign',
+  'Interim Campaign',
+  'Always-On Campaign',
+  'Event-Based Campaign',
+  'Promotional / Discount Campaign',
+  'Other'
 ]
 
-const timelines = ['4 weeks', '6–8 weeks', 'Quarter', 'Custom timeline']
-const budgets = ['₹1–2 Cr', '₹2–4 Cr', '₹4–6 Cr', '₹6+ Cr', 'Undisclosed']
-const referrals = ['Existing client', 'Press feature', 'Conference', 'Direct outreach', 'Other']
+const audienceOptions = ['Existing Customers', 'New Prospects', 'Both']
+
+const deliverableOptions = [
+  'Social media – Static posts',
+  'Social media – GIFs / animated posts',
+  'Short-form video content (e.g., Reels, TikTok, Shorts)',
+  'Long-form video content (e.g., YouTube, explainers)',
+  'TVCs (Television Commercials) & Digital Films',
+  'Display ads / web banners',
+  'Print materials (posters, flyers, brochures)',
+  'Outdoor ads (billboards, signage)',
+  'Other'
+]
+
+const brandToneOptions = [
+  'Professional',
+  'Friendly',
+  'Bold',
+  'Playful',
+  'Inspirational',
+  'Premium',
+  'Minimalist',
+  'Other'
+]
+
+const ctaOptions = ['Awareness & Identity', 'Conversion & Sales', 'Other']
+
+const successMetricOptions = [
+  'Reach',
+  'Impressions',
+  'Brand Recall',
+  'Engagement Rate',
+  'Click-through rate (CTR)',
+  'Leads generated (sign-ups, downloads, form fills)',
+  'Conversion rate (purchases, bookings, sign-ups)',
+  'Cost per acquisition (CPA)',
+  'Return on ad spend (ROAS)',
+  'Other'
+]
+
+function toggleValue(list, value) {
+  if (list.includes(value)) {
+    return list.filter((item) => item !== value)
+  }
+  return [...list, value]
+}
+
+function readFiles(fileList) {
+  const files = Array.from(fileList ?? [])
+  return Promise.all(
+    files.map(
+      (file) =>
+        new Promise((resolve, reject) => {
+          const reader = new FileReader()
+          reader.onload = () => {
+            resolve({
+              name: file.name,
+              type: file.type,
+              size: file.size,
+              dataUrl: typeof reader.result === 'string' ? reader.result : null
+            })
+          }
+          reader.onerror = () => reject(reader.error)
+          reader.readAsDataURL(file)
+        })
+    )
+  )
+}
 
 export function IntakeForm() {
   const [form, setForm] = useState(defaultForm)
@@ -53,19 +139,19 @@ export function IntakeForm() {
   const sections = useMemo(
     () => [
       {
-        key: 'client',
-        title: 'Client information',
-        description: 'Introduce your team so we know who to align with during discovery.'
+        key: 'objectives',
+        title: 'Campaign objectives',
+        description: 'Clarify the goal of this initiative so we align strategy and creative output.'
       },
       {
-        key: 'project',
-        title: 'Project blueprint',
-        description: 'Outline the initiative so we can scope team composition, timeline, and investment.'
+        key: 'audience',
+        title: 'Audience & messaging',
+        description: 'Help us understand who we are speaking to and what they should take away.'
       },
       {
-        key: 'context',
-        title: 'Context & artefacts',
-        description: 'Share touchstones that help us prepare the right POV before our first call.'
+        key: 'deliverables',
+        title: 'Deliverables & logistics',
+        description: 'Outline formats, guardrails, and launch timing so we can scope the work precisely.'
       }
     ],
     []
@@ -126,6 +212,7 @@ export function IntakeForm() {
       console.warn('Failed to persist intake form step', err)
     }
   }, [step, draftReady])
+
   function goToStep(next) {
     setStepErrors({})
     setStep((current) => {
@@ -135,62 +222,99 @@ export function IntakeForm() {
     })
   }
 
-  function validateEmail(value) {
-    return /.+@.+\..+/.test(value.trim())
-  }
-
-  function validatePhone(value) {
-    if (!value.trim()) return true
-    return /^[+()\d\s-]{7,}$/.test(value.trim())
-  }
-
-  function ensureHttpScheme(url) {
-    if (!url) return url
-    const trimmed = url.trim()
-    if (!trimmed) return trimmed
-    // If missing scheme, default to https:// for user convenience
-    if (!/^https?:\/\//i.test(trimmed)) {
-      return `https://${trimmed}`
-    }
-    return trimmed
-  }
-
-  function validateUrls(value) {
-    if (!value.trim()) return true
-    return value
-      .split(',')
-      .map((item) => ensureHttpScheme(item))
-      .filter(Boolean)
-      .every((candidate) => {
-        try {
-          new URL(candidate)
-          return true
-        } catch (err) {
-          return false
-        }
-      })
-  }
-
   function validateStep(currentStep) {
     const errors = {}
+
     if (currentStep === 0) {
-      if (!form.clientName.trim()) errors.clientName = 'Tell us who we are partnering with.'
-      if (!validateEmail(form.email)) errors.email = 'Enter a valid email address.'
-      if (!validatePhone(form.phone)) errors.phone = 'Please include a valid phone number (with country code).'
+      if (!form.objectives.length) errors.objectives = 'Select at least one objective.'
+      if (form.objectives.includes('Other') && !form.objectiveOther.trim()) {
+        errors.objectiveOther = 'Describe the other objective.'
+      }
+      if (!form.campaignType.trim()) errors.campaignType = 'Select a campaign type.'
+      if (form.campaignType === 'Other' && !form.campaignTypeOther.trim()) {
+        errors.campaignTypeOther = 'Describe the campaign type.'
+      }
+      if (!form.ctaFocus.trim()) errors.ctaFocus = 'Select the CTA emphasis.'
+      if (form.ctaFocus === 'Other' && !form.ctaOther.trim()) {
+        errors.ctaOther = 'Describe the CTA focus.'
+      }
     }
+
     if (currentStep === 1) {
-      if (!form.projectTitle.trim()) errors.projectTitle = 'Project title is required.'
-      if (!form.projectType.trim()) errors.projectType = 'Select a project type.'
-      if (!form.timeline.trim()) errors.timeline = 'Select a timeline.'
-      if (!form.budget.trim()) errors.budget = 'Select an investment range.'
-      if (!form.projectDescription.trim()) errors.projectDescription = 'Describe the mandate so we can prepare.'
+      if (!form.demographics.trim()) errors.demographics = 'Describe the demographics.'
+      if (!form.psychographics.trim()) errors.psychographics = 'Share the key psychographics.'
+      if (!form.problemsSolved.trim()) errors.problemsSolved = 'Explain the problems you solve.'
+      if (!form.painPoints.trim()) errors.painPoints = 'Detail the pain points to address.'
+      if (!form.audienceTarget.trim()) errors.audienceTarget = 'Select the primary audience.'
+      if (!form.audienceThinkFeel.trim()) errors.audienceThinkFeel = 'Share the desired takeaway.'
+      if (!form.audienceThinkFeelSecondary.trim()) {
+        errors.audienceThinkFeelSecondary = 'Share the follow-up takeaway.'
+      }
     }
+
     if (currentStep === 2) {
-      if (!validateUrls(form.references)) errors.references = 'One or more reference links look invalid.'
+      if (!form.deliverables.length) errors.deliverables = 'Select at least one deliverable.'
+      if (form.deliverables.includes('Other') && !form.deliverablesOther.trim()) {
+        errors.deliverablesOther = 'Describe the other deliverables.'
+      }
+      if (!form.brandTone.length) errors.brandTone = 'Select the desired tone.'
+      if (form.brandTone.includes('Other') && !form.brandToneOther.trim()) {
+        errors.brandToneOther = 'Describe the additional tone.'
+      }
+      if (!form.mandatoryAssets.length) errors.mandatoryAssets = 'Upload mandatory elements.'
+      if (!form.brandGuidelines.length) errors.brandGuidelines = 'Upload brand guidelines.'
+      if (!form.packShots.length) errors.packShots = 'Upload pack shots or product imagery.'
+      if (!form.budget.trim()) errors.budget = 'Share the investment range or estimate.'
+      if (!form.goLiveDate.trim()) errors.goLiveDate = 'Provide a go-live date.'
+      if (!form.successMetrics.length) errors.successMetrics = 'Select at least one success metric.'
+      if (form.successMetrics.includes('Other') && !form.successMetricsOther.trim()) {
+        errors.successMetricsOther = 'Describe the custom success metric.'
+      }
+      if (!form.generalNotes.trim()) errors.generalNotes = 'Add any additional context.'
     }
 
     setStepErrors(errors)
     return Object.keys(errors).length === 0
+  }
+
+  function validateAll() {
+    for (let i = 0; i < sections.length; i += 1) {
+      if (!validateStep(i)) {
+        setStep(i)
+        return false
+      }
+    }
+    return true
+  }
+
+  function buildSummaryPayload() {
+    const lines = [
+      `Objectives: ${form.objectives.filter((item) => item !== 'Other').join(', ')}`,
+      form.objectives.includes('Other') && form.objectiveOther.trim()
+        ? `Objective (Other): ${form.objectiveOther.trim()}`
+        : null,
+      `Campaign type: ${
+        form.campaignType === 'Other' ? form.campaignTypeOther.trim() || 'Other' : form.campaignType
+      }`,
+      `CTA focus: ${form.ctaFocus === 'Other' ? form.ctaOther.trim() || 'Other' : form.ctaFocus}`,
+      `Audience: ${form.audienceTarget}`,
+      `Deliverables: ${form.deliverables.filter((item) => item !== 'Other').join(', ')}`,
+      form.deliverables.includes('Other') && form.deliverablesOther.trim()
+        ? `Deliverables (Other): ${form.deliverablesOther.trim()}`
+        : null,
+      `Brand tone: ${form.brandTone.filter((item) => item !== 'Other').join(', ')}`,
+      form.brandTone.includes('Other') && form.brandToneOther.trim()
+        ? `Brand tone (Other): ${form.brandToneOther.trim()}`
+        : null,
+      `Budget: ${form.budget}`,
+      `Go-live date: ${form.goLiveDate}`,
+      `Success metrics: ${form.successMetrics.filter((item) => item !== 'Other').join(', ')}`,
+      form.successMetrics.includes('Other') && form.successMetricsOther.trim()
+        ? `Success metrics (Other): ${form.successMetricsOther.trim()}`
+        : null
+    ].filter(Boolean)
+
+    return `${lines.join('\n')}`
   }
 
   async function submit(event) {
@@ -199,42 +323,48 @@ export function IntakeForm() {
     setShowSuccess(false)
     setAuthRequired(false)
 
-    // Ensure all steps are valid before submitting (users might edit earlier steps)
-    function validateAll() {
-      for (let i = 0; i < sections.length; i++) {
-        if (!validateStep(i)) {
-          setStep(i)
-          return false
-        }
-      }
-      return true
-    }
-
     if (!validateAll()) return
 
     setLoading(true)
+
+    const metadata = {
+      objectives: form.objectives,
+      objectiveOther: form.objectiveOther.trim() || null,
+      campaignType: form.campaignType,
+      campaignTypeOther: form.campaignTypeOther.trim() || null,
+      demographics: form.demographics.trim(),
+      psychographics: form.psychographics.trim(),
+      problemsSolved: form.problemsSolved.trim(),
+      painPoints: form.painPoints.trim(),
+      audienceTarget: form.audienceTarget,
+      personasFiles: form.personasFiles,
+      audienceThinkFeel: form.audienceThinkFeel.trim(),
+      audienceThinkFeelSecondary: form.audienceThinkFeelSecondary.trim(),
+      deliverables: form.deliverables,
+      deliverablesOther: form.deliverablesOther.trim() || null,
+      brandTone: form.brandTone,
+      brandToneOther: form.brandToneOther.trim() || null,
+      referenceCampaigns: form.referenceCampaigns,
+      ctaFocus: form.ctaFocus,
+      ctaOther: form.ctaOther.trim() || null,
+      mandatoryAssets: form.mandatoryAssets,
+      brandGuidelines: form.brandGuidelines,
+      packShots: form.packShots,
+      budget: form.budget.trim(),
+      goLiveDate: form.goLiveDate,
+      successMetrics: form.successMetrics,
+      successMetricsOther: form.successMetricsOther.trim() || null,
+      generalNotes: form.generalNotes.trim()
+    }
 
     try {
       const response = await fetch('/api/submissions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          name: form.projectTitle || form.clientName || 'Untitled engagement',
-          email: form.email,
-          details: form.projectDescription,
-          metadata: {
-            clientName: form.clientName || null,
-            company: form.company || null,
-            phone: form.phone || null,
-            projectTitle: form.projectTitle || null,
-            projectType: form.projectType || null,
-            timeline: form.timeline || null,
-            budget: form.budget || null,
-            keyMoment: form.keyMoment || null,
-            additionalNotes: form.additionalNotes || null,
-            referralSource: form.referralSource || null,
-            references: parseReferences(form.references)
-          }
+          name: form.campaignType || 'Campaign brief',
+          details: `${buildSummaryPayload()}\n\nGeneral notes:\n${form.generalNotes.trim()}`,
+          metadata
         })
       })
 
@@ -253,7 +383,7 @@ export function IntakeForm() {
       if (!response.ok) {
         const payload = await response.json().catch(() => null)
         const message = payload && typeof payload === 'object' && 'error' in payload ? payload.error : null
-        throw new Error(message ?? 'Failed to submit project')
+        throw new Error(message ?? 'Failed to submit campaign brief')
       }
 
       const payload = await response.json()
@@ -272,7 +402,7 @@ export function IntakeForm() {
         console.warn('Failed to clear intake form draft after submission', err)
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to submit project')
+      setError(err instanceof Error ? err.message : 'Failed to submit campaign brief')
     } finally {
       setLoading(false)
     }
@@ -282,35 +412,53 @@ export function IntakeForm() {
     <div className="mx-auto flex max-w-5xl flex-col gap-16">
       <header className="space-y-4 text-center">
         <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-5 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-white/70">
-          Glassbox studio intake
+          Campaign intake
         </span>
         <h1 className="text-4xl font-semibold leading-tight text-white sm:text-5xl">
-          Tell us about the launch you want to see
+          Brief us on GB x Komerz: Streamlining our Workflow
         </h1>
         <p className="mx-auto max-w-2xl text-sm text-white/70">
-          A few considered details help us assemble the right strategists, designers, and producers. Expect a tailored response within one business day.
+          Share campaign objectives, audience insights, and required assets so we can orchestrate a focused launch plan within one business day.
         </p>
       </header>
 
-      <Progress steps={sections} current={step} onNavigate={(index) => validateStep(step) && index <= step ? goToStep(index) : null} />
+      <Progress steps={sections} current={step} onNavigate={(index) => (validateStep(step) && index <= step ? goToStep(index) : null)} />
 
       {showSuccess ? (
         <div className="rounded-[28px] border border-primary/20 bg-primary/10 p-8 text-center text-sm text-white/75">
-          <h2 className="text-xl font-semibold text-white">Thanks for the brief.</h2>
+          <h2 className="text-xl font-semibold text-white">Thanks for the download.</h2>
           <p className="mt-2">
-            Our concierge has your request. Expect an email within one business day with discovery availability.
+            Our campaign pod is on it. Expect a follow-up email shortly with next steps and availability for kickoff.
           </p>
         </div>
       ) : null}
 
       <form onSubmit={submit} className="space-y-10">
-        {step === 0 ? <ClientSection form={form} setForm={setForm} errors={stepErrors} /> : null}
-        {step === 1 ? <ProjectSection form={form} setForm={setForm} errors={stepErrors} /> : null}
-        {step === 2 ? <ContextSection form={form} setForm={setForm} errors={stepErrors} /> : null}
+        {step === 0 ? (
+          <ObjectivesSection
+            form={form}
+            setForm={setForm}
+            errors={stepErrors}
+          />
+        ) : null}
+        {step === 1 ? (
+          <AudienceSection
+            form={form}
+            setForm={setForm}
+            errors={stepErrors}
+          />
+        ) : null}
+        {step === 2 ? (
+          <DeliverablesSection
+            form={form}
+            setForm={setForm}
+            errors={stepErrors}
+          />
+        ) : null}
 
         <div className="flex flex-wrap items-center justify-between gap-4 rounded-[28px] border border-white/10 bg-white/5 px-6 py-5 backdrop-blur-xl">
           <p className="text-xs text-white/60">
-            Our concierge will connect within one business day with next steps and scheduling options.
+            Our campaign leads respond within one business day with the proposed approach and timeline.
           </p>
           <div className="flex items-center gap-3">
             <div className="flex flex-col items-start gap-1 text-left">
@@ -348,7 +496,7 @@ export function IntakeForm() {
                 </button>
               ) : (
                 <button type="submit" disabled={loading} className="min-w-[200px] justify-center">
-                  {loading ? 'Preparing concierge…' : 'Submit engagement request'}
+                  {loading ? 'Submitting campaign brief…' : 'Submit campaign brief'}
                 </button>
               )}
             </div>
@@ -389,26 +537,12 @@ export function IntakeForm() {
             <div className="grid gap-3 text-xs text-white/60">
               <DetailRow label="Status" value={submission.status} />
               <DetailRow label="Primary contact" value={submission.email} />
-              <DetailRow label="Project" value={submission.metadata?.projectTitle ?? '—'} />
-              <DetailRow label="Investment" value={submission.metadata?.budget ?? '—'} />
-              <DetailRow label="Key moment" value={submission.metadata?.keyMoment ?? '—'} />
+              <DetailRow label="Campaign type" value={submission.metadata?.campaignType ?? '—'} />
+              <DetailRow label="Go-live date" value={submission.metadata?.goLiveDate ?? '—'} />
+              <DetailRow label="Budget" value={submission.metadata?.budget ?? '—'} />
             </div>
-            {Array.isArray(submission.metadata?.references) && submission.metadata.references.length ? (
-              <div className="rounded-2xl border border-white/8 bg-white/5 p-4 text-xs text-white/70">
-                <p className="font-semibold text-white">Reference links</p>
-                <ul className="mt-2 space-y-1">
-                  {submission.metadata.references.map((item, index) => (
-                    <li key={`${item.url}-${index}`} className="truncate">
-                      <a className="text-primary" href={item.url} target="_blank" rel="noreferrer">
-                        {item.name || item.url}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
             <div className="space-y-2 text-xs text-white/60">
-              <p className="font-semibold text-white">Project narrative</p>
+              <p className="font-semibold text-white">Campaign narrative</p>
               <div className="max-h-48 overflow-auto rounded-2xl border border-white/8 bg-[#0b0c10] p-4 text-[11px] leading-relaxed">
                 {submission.details}
               </div>
@@ -457,7 +591,7 @@ function Field({ label, hint, children, required, error }) {
             'w-full',
             error ? 'border-rose-500/60 focus:border-rose-400/70 focus:ring-rose-400/30' : '',
             children.props.className
-          ),
+          )
         })
       : children
 
@@ -515,185 +649,431 @@ function Progress({ steps, current, onNavigate }) {
   )
 }
 
-function ClientSection({ form, setForm, errors }) {
+function CheckboxGrid({ options, value, onChange }) {
   return (
-    <FormBlock
-      title="Client information"
-      description="Introduce your team so we know who to align with during discovery."
-    >
-      <div className="grid gap-6 md:grid-cols-2">
-        <Field label="Full name" required error={errors.clientName}>
-          <input
-            required
-            value={form.clientName}
-            onChange={(event) => setForm((prev) => ({ ...prev, clientName: event.target.value }))}
-            placeholder="Aarav Mehta"
-          />
-        </Field>
-        <Field label="Company" hint="Optional">
-          <input
-            value={form.company}
-            onChange={(event) => setForm((prev) => ({ ...prev, company: event.target.value }))}
-            placeholder="Glassbox Ventures"
-          />
-        </Field>
-        <Field label="Email" required error={errors.email}>
-          <input
-            required
-            type="email"
-            value={form.email}
-            onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
-            placeholder="you@brandgroup.com"
-          />
-        </Field>
-        <Field label="Phone" hint="Include country code" error={errors.phone}>
-          <input
-            value={form.phone}
-            onChange={(event) => setForm((prev) => ({ ...prev, phone: event.target.value }))}
-            placeholder="+91 98 1234 5678"
-          />
-        </Field>
-      </div>
-    </FormBlock>
+    <div className="grid gap-3 sm:grid-cols-2">
+      {options.map((option) => {
+        const checked = value.includes(option)
+        return (
+          <button
+            type="button"
+            key={option}
+            onClick={() => onChange(toggleValue(value, option))}
+            className={clsx(
+              'rounded-2xl border px-4 py-3 text-left text-sm transition',
+              checked ? 'border-white/60 bg-white/15 text-white' : 'border-white/10 bg-transparent text-white/70 hover:border-white/20'
+            )}
+          >
+            {option}
+          </button>
+        )
+      })}
+    </div>
   )
 }
 
-function ProjectSection({ form, setForm, errors }) {
+function RadioGrid({ options, value, onChange }) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {options.map((option) => {
+        const checked = value === option
+        return (
+          <button
+            type="button"
+            key={option}
+            onClick={() => onChange(option)}
+            className={clsx(
+              'rounded-2xl border px-4 py-3 text-left text-sm transition',
+              checked ? 'border-white/60 bg-white/15 text-white' : 'border-white/10 bg-transparent text-white/70 hover:border-white/20'
+            )}
+          >
+            {option}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function FileUploadField({ label, hint, value, onChange, multiple = true, required, error, accept }) {
+  async function handleSelection(event) {
+    const files = event.target.files
+    if (!files || !files.length) return
+    try {
+      const results = await readFiles(files)
+      onChange(multiple ? [...value, ...results] : results.slice(0, 1))
+    } catch (err) {
+      console.warn('Failed to read files', err)
+    } finally {
+      event.target.value = ''
+    }
+  }
+
+  function removeFile(index) {
+    onChange(value.filter((_, idx) => idx !== index))
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-baseline justify-between gap-4">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white/70">
+          {label}
+          {required ? <span className="text-white/50"> *</span> : null}
+        </span>
+        {hint ? <span className="text-xs text-white/50">{hint}</span> : null}
+      </div>
+      <div className="flex flex-col gap-3 rounded-2xl border border-dashed border-white/20 bg-white/5 p-5">
+        <input
+          type="file"
+          accept={accept}
+          multiple={multiple}
+          onChange={handleSelection}
+          className="text-sm text-white/80 file:mr-3 file:rounded-full file:border file:border-white/20 file:bg-white/10 file:px-4 file:py-2 file:text-xs file:uppercase file:tracking-[0.22em] file:text-white/70 hover:file:bg-white/20"
+        />
+        {value.length ? (
+          <ul className="space-y-2 text-xs text-white/70">
+            {value.map((file, index) => (
+              <li key={`${file.name}-${index}`} className="flex items-center justify-between gap-3">
+                <span className="truncate">{file.name}</span>
+                <button
+                  type="button"
+                  onClick={() => removeFile(index)}
+                  className="text-rose-300 hover:text-rose-200"
+                >
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-xs text-white/50">No files added yet.</p>
+        )}
+      </div>
+      {error ? <span className="text-xs text-rose-400">{error}</span> : null}
+    </div>
+  )
+}
+
+function ObjectivesSection({ form, setForm, errors }) {
   return (
     <FormBlock
-      title="Project blueprint"
-      description="Outline the initiative so we can scope team composition, timeline, and investment."
+      title="Campaign objectives"
+      description="Clarify what success looks like so the strategy team can respond with precision."
     >
-      <div className="grid gap-6 md:grid-cols-2">
-        <Field label="Project title" required error={errors.projectTitle}>
-          <input
-            required
-            value={form.projectTitle}
-            onChange={(event) => setForm((prev) => ({ ...prev, projectTitle: event.target.value }))}
-            placeholder="Aurora launch"
-          />
-        </Field>
-        <Field label="Project type" required error={errors.projectType}>
-          <select
-            value={form.projectType}
-            onChange={(event) => setForm((prev) => ({ ...prev, projectType: event.target.value }))}
-          >
-            <option value="">Select project type</option>
-            {projectTypes.map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            ))}
-            <option value="Other">Other</option>
-          </select>
-        </Field>
-        <Field label="Ideal timeline" required error={errors.timeline}>
-          <select
-            value={form.timeline}
-            onChange={(event) => setForm((prev) => ({ ...prev, timeline: event.target.value }))}
-          >
-            <option value="">Select timeline</option>
-            {timelines.map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            ))}
-          </select>
-        </Field>
-        <Field label="Investment posture" required error={errors.budget}>
-          <select
-            value={form.budget}
-            onChange={(event) => setForm((prev) => ({ ...prev, budget: event.target.value }))}
-          >
-            <option value="">Select budget range</option>
-            {budgets.map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            ))}
-          </select>
-        </Field>
-      </div>
-      <Field label="Project narrative" required hint="Goals, audience, success metrics, decision makers." error={errors.projectDescription}>
-        <textarea
-          required
-          rows={6}
-          value={form.projectDescription}
-          onChange={(event) => setForm((prev) => ({ ...prev, projectDescription: event.target.value }))}
-          placeholder="Outline the ambition, the moments you must own, and what success unlocks."
-          className="min-h-[180px]"
+      <Field label="What is the objective of this campaign?" required error={errors.objectives}>
+        <CheckboxGrid
+          options={objectiveOptions}
+          value={form.objectives}
+          onChange={(next) => setForm((prev) => ({ ...prev, objectives: next }))}
         />
       </Field>
+      {form.objectives.includes('Other') ? (
+        <Field
+          label="Objective — Other"
+          hint="Describe the additional outcome we should prioritize"
+          required
+          error={errors.objectiveOther}
+        >
+          <textarea
+            rows={3}
+            value={form.objectiveOther}
+            onChange={(event) => setForm((prev) => ({ ...prev, objectiveOther: event.target.value }))}
+            placeholder="Expand on the unique objective driving this campaign."
+            className="min-h-[120px]"
+          />
+        </Field>
+      ) : null}
+      <Field label="What type of campaign is this?" required error={errors.campaignType}>
+        <RadioGrid
+          options={campaignTypeOptions}
+          value={form.campaignType}
+          onChange={(next) =>
+            setForm((prev) => ({
+              ...prev,
+              campaignType: next,
+              campaignTypeOther: next === 'Other' ? prev.campaignTypeOther : ''
+            }))
+          }
+        />
+      </Field>
+      {form.campaignType === 'Other' ? (
+        <Field
+          label="Campaign type — Other"
+          required
+          error={errors.campaignTypeOther}
+        >
+          <input
+            value={form.campaignTypeOther}
+            onChange={(event) => setForm((prev) => ({ ...prev, campaignTypeOther: event.target.value }))}
+            placeholder="Describe the campaign format."
+          />
+        </Field>
+      ) : null}
+      <Field label="What should the CTA lean more towards?" required error={errors.ctaFocus}>
+        <RadioGrid
+          options={ctaOptions}
+          value={form.ctaFocus}
+          onChange={(next) =>
+            setForm((prev) => ({
+              ...prev,
+              ctaFocus: next,
+              ctaOther: next === 'Other' ? prev.ctaOther : ''
+            }))
+          }
+        />
+      </Field>
+      {form.ctaFocus === 'Other' ? (
+        <Field
+          label="CTA focus — Other"
+          required
+          error={errors.ctaOther}
+        >
+          <input
+            value={form.ctaOther}
+            onChange={(event) => setForm((prev) => ({ ...prev, ctaOther: event.target.value }))}
+            placeholder="Describe the CTA focus in your words."
+          />
+        </Field>
+      ) : null}
     </FormBlock>
   )
 }
 
-function ContextSection({ form, setForm, errors }) {
+function AudienceSection({ form, setForm, errors }) {
   return (
     <FormBlock
-      title="Context & artefacts"
-      description="Share touchstones that help us prepare the right POV before our first call."
+      title="Audience & messaging"
+      description="Explain who we are speaking to and what transformation they should experience."
     >
-      <div className="grid gap-6 md:grid-cols-2">
-        <Field label="Key moment" hint="Launch date, event, or campaign window">
-          <input
-            type="date"
-            value={form.keyMoment}
-            onChange={(event) => setForm((prev) => ({ ...prev, keyMoment: event.target.value }))}
-          />
-        </Field>
-        <Field label="Reference links" hint="Paste URLs separated by commas" error={errors.references}>
-          <input
-            value={form.references}
-            onChange={(event) => setForm((prev) => ({ ...prev, references: event.target.value }))}
-            placeholder="https://brandbook.com, https://moodboard.io/..."
-          />
-        </Field>
-      </div>
-      <Field label="Additional requirements" hint="Integrations, experiential needs, or quick notes">
+      <Field
+        label="Who are we targeting? (demographics)"
+        required
+        error={errors.demographics}
+        hint="Age, location, role, income band, etc."
+      >
         <textarea
           rows={4}
-          value={form.additionalNotes}
-          onChange={(event) => setForm((prev) => ({ ...prev, additionalNotes: event.target.value }))}
-          placeholder="Mention must-have channels, tech preferences, or activations."
+          value={form.demographics}
+          onChange={(event) => setForm((prev) => ({ ...prev, demographics: event.target.value }))}
+          placeholder="Outline the primary demographic profile in as much detail as possible."
+          className="min-h-[140px]"
         />
       </Field>
-      <Field label="How did you hear about us?" hint="Optional">
-        <select
-          value={form.referralSource}
-          onChange={(event) => setForm((prev) => ({ ...prev, referralSource: event.target.value }))}
-        >
-          <option value="">Select referral source</option>
-          {referrals.map((option) => (
-            <option key={option} value={option}>
-              {option}
-            </option>
-          ))}
-        </select>
+      <Field
+        label="What psychographics matter most?"
+        required
+        error={errors.psychographics}
+        hint="Values, behaviours, affinities, and motivations"
+      >
+        <textarea
+          rows={4}
+          value={form.psychographics}
+          onChange={(event) => setForm((prev) => ({ ...prev, psychographics: event.target.value }))}
+          placeholder="Describe beliefs, interests, and lifestyle cues that define this audience."
+          className="min-h-[140px]"
+        />
       </Field>
-      <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-white/70">
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">What helps us prepare</p>
-        <ul className="mt-3 space-y-2">
-          {guidance.map((tip) => (
-            <li key={tip} className="flex items-start gap-3">
-              <span className="mt-1 h-2 w-2 flex-none rounded-full bg-white/60" aria-hidden="true" />
-              <p className="leading-relaxed">{tip}</p>
-            </li>
-          ))}
-        </ul>
-      </div>
+      <Field
+        label="What problems or needs does your product/service solve for them?"
+        required
+        error={errors.problemsSolved}
+      >
+        <textarea
+          rows={4}
+          value={form.problemsSolved}
+          onChange={(event) => setForm((prev) => ({ ...prev, problemsSolved: event.target.value }))}
+          placeholder="Explain the core jobs-to-be-done and outcomes your offer delivers."
+          className="min-h-[140px]"
+        />
+      </Field>
+      <Field
+        label="What pain points, desires, or motivations should we address?"
+        required
+        error={errors.painPoints}
+      >
+        <textarea
+          rows={4}
+          value={form.painPoints}
+          onChange={(event) => setForm((prev) => ({ ...prev, painPoints: event.target.value }))}
+          placeholder="List the barriers, objections, and sparks we should lean into."
+          className="min-h-[140px]"
+        />
+      </Field>
+      <Field label="Are we targeting existing customers, new prospects, or both?" required error={errors.audienceTarget}>
+        <RadioGrid
+          options={audienceOptions}
+          value={form.audienceTarget}
+          onChange={(next) => setForm((prev) => ({ ...prev, audienceTarget: next }))}
+        />
+      </Field>
+      <FileUploadField
+        label="Do you have buyer personas, audience segments, or market research we should reference?"
+        hint="Upload PDFs, decks, or docs (optional)"
+        value={form.personasFiles}
+        onChange={(next) => setForm((prev) => ({ ...prev, personasFiles: next }))}
+        multiple={false}
+        error={errors.personasFiles}
+      />
+      <Field
+        label="What do you want the audience think/feel after interacting with this work?"
+        required
+        error={errors.audienceThinkFeel}
+      >
+        <textarea
+          rows={4}
+          value={form.audienceThinkFeel}
+          onChange={(event) => setForm((prev) => ({ ...prev, audienceThinkFeel: event.target.value }))}
+          placeholder="Describe the primary emotional or cognitive shift you expect."
+          className="min-h-[140px]"
+        />
+      </Field>
+      <Field
+        label="What do you want the audience think/feel after interacting with this work? (Part 2)"
+        required
+        error={errors.audienceThinkFeelSecondary}
+        hint="Use this to expand on behaviour changes or reinforcing feelings"
+      >
+        <textarea
+          rows={4}
+          value={form.audienceThinkFeelSecondary}
+          onChange={(event) =>
+            setForm((prev) => ({ ...prev, audienceThinkFeelSecondary: event.target.value }))
+          }
+          placeholder="Add nuance or secondary reactions you want to guarantee."
+          className="min-h-[140px]"
+        />
+      </Field>
     </FormBlock>
   )
 }
 
-function parseReferences(value) {
-  if (!value.trim()) return []
-  return value
-    .split(',')
-    .map((item) => item.trim())
-    .filter(Boolean)
-    .map((raw, index) => {
-      const url = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`
-      return { url, name: `Reference ${index + 1}` }
-    })
+function DeliverablesSection({ form, setForm, errors }) {
+  return (
+    <FormBlock
+      title="Deliverables & logistics"
+      description="Capture the production scope, mandatory elements, and success metrics."
+    >
+      <Field label="What formats/deliverables do you need?" required error={errors.deliverables}>
+        <CheckboxGrid
+          options={deliverableOptions}
+          value={form.deliverables}
+          onChange={(next) => setForm((prev) => ({ ...prev, deliverables: next }))}
+        />
+      </Field>
+      {form.deliverables.includes('Other') ? (
+        <Field
+          label="Deliverables — Other"
+          required
+          error={errors.deliverablesOther}
+        >
+          <textarea
+            rows={3}
+            value={form.deliverablesOther}
+            onChange={(event) => setForm((prev) => ({ ...prev, deliverablesOther: event.target.value }))}
+            placeholder="Outline additional deliverables, specs, or formats."
+            className="min-h-[120px]"
+          />
+        </Field>
+      ) : null}
+      <Field label="How would you like your brand to come across in this campaign?" required error={errors.brandTone}>
+        <CheckboxGrid
+          options={brandToneOptions}
+          value={form.brandTone}
+          onChange={(next) => setForm((prev) => ({ ...prev, brandTone: next }))}
+        />
+      </Field>
+      {form.brandTone.includes('Other') ? (
+        <Field
+          label="Brand tone — Other"
+          required
+          error={errors.brandToneOther}
+        >
+          <textarea
+            rows={3}
+            value={form.brandToneOther}
+            onChange={(event) => setForm((prev) => ({ ...prev, brandToneOther: event.target.value }))}
+            placeholder="Describe the unique tone or mood we should convey."
+            className="min-h-[120px]"
+          />
+        </Field>
+      ) : null}
+      <FileUploadField
+        label="Do you have reference campaigns, brands, or moodboards we should take inspiration from?"
+        hint="Upload up to 5 files"
+        value={form.referenceCampaigns}
+        onChange={(next) => setForm((prev) => ({ ...prev, referenceCampaigns: next }))}
+      />
+      <FileUploadField
+        label="Please upload any mandatory elements that must appear in this campaign"
+        hint="Upload logos, taglines, disclaimers, etc."
+        value={form.mandatoryAssets}
+        onChange={(next) => setForm((prev) => ({ ...prev, mandatoryAssets: next }))}
+        required
+        error={errors.mandatoryAssets}
+      />
+      <FileUploadField
+        label="Please upload any brand guidelines (logos, fonts, colours, etc.) we should follow"
+        value={form.brandGuidelines}
+        onChange={(next) => setForm((prev) => ({ ...prev, brandGuidelines: next }))}
+        required
+        error={errors.brandGuidelines}
+      />
+      <FileUploadField
+        label="Please upload any pack shots/product images we should use"
+        value={form.packShots}
+        onChange={(next) => setForm((prev) => ({ ...prev, packShots: next }))}
+        required
+        error={errors.packShots}
+      />
+      <Field label="What is the Budget?" required error={errors.budget}>
+        <input
+          value={form.budget}
+          onChange={(event) => setForm((prev) => ({ ...prev, budget: event.target.value }))}
+          placeholder="Share the working budget or range."
+        />
+      </Field>
+      <Field label="What is the Go-live date?" required error={errors.goLiveDate}>
+        <input
+          type="date"
+          value={form.goLiveDate}
+          onChange={(event) => setForm((prev) => ({ ...prev, goLiveDate: event.target.value }))}
+        />
+      </Field>
+      <Field label="How would you measure the success of this campaign" required error={errors.successMetrics}>
+        <CheckboxGrid
+          options={successMetricOptions}
+          value={form.successMetrics}
+          onChange={(next) => setForm((prev) => ({ ...prev, successMetrics: next }))}
+        />
+      </Field>
+      {form.successMetrics.includes('Other') ? (
+        <Field
+          label="Success metrics — Other"
+          required
+          error={errors.successMetricsOther}
+        >
+          <textarea
+            rows={3}
+            value={form.successMetricsOther}
+            onChange={(event) => setForm((prev) => ({ ...prev, successMetricsOther: event.target.value }))}
+            placeholder="Specify the metric or measurement framework."
+            className="min-h-[120px]"
+          />
+        </Field>
+      ) : null}
+      <Field
+        label="General Notes (anything else we should know)"
+        required
+        error={errors.generalNotes}
+      >
+        <textarea
+          rows={4}
+          value={form.generalNotes}
+          onChange={(event) => setForm((prev) => ({ ...prev, generalNotes: event.target.value }))}
+          placeholder="Flag approvals, redlines, timelines, or additional context your team wants us to note."
+          className="min-h-[140px]"
+        />
+      </Field>
+    </FormBlock>
+  )
 }

--- a/lib/submission-store.js
+++ b/lib/submission-store.js
@@ -88,6 +88,31 @@ function sanitizeReferences(value) {
     .filter(Boolean)
 }
 
+function arrayOfStrings(value) {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item) => (typeof item === 'string' ? item.trim() : ''))
+    .filter((item) => item.length > 0)
+}
+
+function sanitizeFileEntry(file) {
+  if (!file || typeof file !== 'object') return null
+
+  const name = typeof file.name === 'string' ? file.name.trim() : ''
+  if (!name) return null
+
+  const dataUrl = typeof file.dataUrl === 'string' ? file.dataUrl : null
+  const type = typeof file.type === 'string' ? file.type : null
+  const size = typeof file.size === 'number' ? file.size : null
+
+  return { name, type, size, dataUrl }
+}
+
+function sanitizeFileCollection(value) {
+  if (!Array.isArray(value)) return []
+  return value.map((item) => sanitizeFileEntry(item)).filter(Boolean)
+}
+
 function sanitizeMetadata(input = {}) {
   const metadata = {
     clientName: stringOrNull(input.clientName) ?? null,
@@ -100,7 +125,30 @@ function sanitizeMetadata(input = {}) {
     keyMoment: normalizeDateish(input.keyMoment),
     additionalNotes: stringOrNull(input.additionalNotes) ?? null,
     referralSource: stringOrNull(input.referralSource) ?? null,
-    references: sanitizeReferences(input.references)
+    references: sanitizeReferences(input.references),
+    objectives: arrayOfStrings(input.objectives),
+    objectiveOther: stringOrNull(input.objectiveOther) ?? null,
+    demographics: stringOrNull(input.demographics) ?? null,
+    psychographics: stringOrNull(input.psychographics) ?? null,
+    problemsSolved: stringOrNull(input.problemsSolved) ?? null,
+    painPoints: stringOrNull(input.painPoints) ?? null,
+    audienceTarget: stringOrNull(input.audienceTarget) ?? null,
+    personasFiles: sanitizeFileCollection(input.personasFiles),
+    audienceThinkFeel: stringOrNull(input.audienceThinkFeel) ?? null,
+    audienceThinkFeelSecondary: stringOrNull(input.audienceThinkFeelSecondary) ?? null,
+    deliverables: arrayOfStrings(input.deliverables),
+    deliverablesOther: stringOrNull(input.deliverablesOther) ?? null,
+    brandTone: arrayOfStrings(input.brandTone),
+    brandToneOther: stringOrNull(input.brandToneOther) ?? null,
+    referenceCampaigns: sanitizeFileCollection(input.referenceCampaigns),
+    ctaFocus: stringOrNull(input.ctaFocus) ?? null,
+    ctaOther: stringOrNull(input.ctaOther) ?? null,
+    mandatoryAssets: sanitizeFileCollection(input.mandatoryAssets),
+    brandGuidelines: sanitizeFileCollection(input.brandGuidelines),
+    packShots: sanitizeFileCollection(input.packShots),
+    successMetrics: arrayOfStrings(input.successMetrics),
+    successMetricsOther: stringOrNull(input.successMetricsOther) ?? null,
+    generalNotes: stringOrNull(input.generalNotes) ?? null
   }
 
   return metadata
@@ -306,6 +354,7 @@ export async function findSubmission(id) {
 export async function createSubmission(input) {
   const supabase = getSupabaseClient()
   const sanitizedMetadata = sanitizeMetadata({
+    ...(input.metadata && typeof input.metadata === 'object' ? input.metadata : {}),
     clientName: input.clientName,
     company: input.company,
     phone: input.phone,


### PR DESCRIPTION
## Summary
- replace the intake form with the GB x Komerz campaign questionnaire, covering objectives, audience insights, deliverables, and required uploads
- add client-side validation, file handling, and submission metadata packaging for the new fields
- update the submissions API and metadata sanitization to derive contact email from the session and persist the expanded campaign data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68db8d63bee48333805d7d2de7fe123c