### PR TITLE
Fix hover styling for intake form options

### DIFF
--- a/components/IntakeForm.jsx
+++ b/components/IntakeForm.jsx
@@ -660,8 +660,10 @@ function CheckboxGrid({ options, value, onChange }) {
             key={option}
             onClick={() => onChange(toggleValue(value, option))}
             className={clsx(
-              'rounded-2xl border px-4 py-3 text-left text-sm transition',
-              checked ? 'border-white/60 bg-white/15 text-white' : 'border-white/10 bg-transparent text-white/70 hover:border-white/20'
+              'flex items-start justify-start rounded-2xl border px-4 py-3 text-left text-sm transition focus-visible:!outline-none focus-visible:!ring-0 hover:!text-[#111216]',
+              checked
+                ? 'border-white/60 bg-white/15 text-white hover:border-white/70 hover:!bg-white'
+                : 'border-white/10 !bg-transparent text-white/70 hover:border-white/40 hover:!bg-white'
             )}
           >
             {option}
@@ -683,8 +685,10 @@ function RadioGrid({ options, value, onChange }) {
             key={option}
             onClick={() => onChange(option)}
             className={clsx(
-              'rounded-2xl border px-4 py-3 text-left text-sm transition',
-              checked ? 'border-white/60 bg-white/15 text-white' : 'border-white/10 bg-transparent text-white/70 hover:border-white/20'
+              'flex items-start justify-start rounded-2xl border px-4 py-3 text-left text-sm transition focus-visible:!outline-none focus-visible:!ring-0 hover:!text-[#111216]',
+              checked
+                ? 'border-white/60 bg-white/15 text-white hover:border-white/70 hover:!bg-white'
+                : 'border-white/10 !bg-transparent text-white/70 hover:border-white/40 hover:!bg-white'
             )}
           >
             {option}


### PR DESCRIPTION
## Summary
- update campaign intake checkbox and radio option buttons to use flex layout overrides so they no longer inherit the global button hover background
- add explicit hover overrides that flip the text color to black while the option background turns light for improved readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68db9a1db7bc8333a903639b15d729f3