### PR TITLE
Switch UI to black and white theme

### DIFF
--- a/app/(app)/dashboard/page.jsx
+++ b/app/(app)/dashboard/page.jsx
@@ -42,11 +42,11 @@ export default async function DashboardPage({ searchParams }) {
         />
       </section>
 
-      <section className="overflow-hidden rounded-[32px] border border-white/10 bg-white/10 shadow-[0_34px_82px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
+      <section className="overflow-hidden rounded-[32px] border border-white/10 bg-white/10 shadow-[0_34px_82px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
         <header className="flex flex-wrap items-center justify-between gap-4 border-b border-white/10 px-8 py-6">
           <div className="space-y-2">
             <h2 className="text-lg font-semibold text-white">Submission portfolio</h2>
-            <p className="text-xs uppercase tracking-[0.28em] text-slate-400">Filter and triage current engagements</p>
+            <p className="text-xs uppercase tracking-[0.28em] text-neutral-400">Filter and triage current engagements</p>
             <Filters filters={filters} />
           </div>
           <Link
@@ -68,14 +68,14 @@ export default async function DashboardPage({ searchParams }) {
                 <th className="px-8 py-4 text-left">Actions</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-white/8 text-sm text-slate-200/85">
+            <tbody className="divide-y divide-white/8 text-sm text-neutral-200/85">
               {filtered.map((submission) => (
                 <tr key={submission.id} className="transition duration-200 hover:bg-white/[0.06]">
                   <td className="px-8 py-5">
                     <Link className="font-semibold text-white hover:text-primary" href={`/projects/${submission.id}`}>
                       {submission.metadata?.projectTitle ?? submission.name}
                     </Link>
-                    <p className="mt-1 text-xs text-slate-400 line-clamp-1">{submission.details}</p>
+                    <p className="mt-1 text-xs text-neutral-400 line-clamp-1">{submission.details}</p>
                   </td>
                   <td className="px-8 py-5">
                     <ProjectTypeBadge type={submission.metadata?.projectType ?? 'other'} />
@@ -83,14 +83,14 @@ export default async function DashboardPage({ searchParams }) {
                   <td className="px-8 py-5">
                     <StatusPill status={submission.status} />
                   </td>
-                  <td className="px-8 py-5 text-slate-400">
+                  <td className="px-8 py-5 text-neutral-400">
                     <span className="block text-white/80">{submission.metadata?.clientName ?? '—'}</span>
                     <span className="text-xs text-white/50">{submission.email}</span>
                   </td>
-                  <td className="px-8 py-5 text-slate-400">
+                  <td className="px-8 py-5 text-neutral-400">
                     <div className="flex flex-col">
                       <span>{formatSubmittedDate(submission.createdAt)}</span>
-                      <span className="text-xs text-slate-500">{formatSubmittedRelative(submission.createdAt)}</span>
+                      <span className="text-xs text-neutral-500">{formatSubmittedRelative(submission.createdAt)}</span>
                     </div>
                   </td>
                   <td className="px-8 py-5">
@@ -113,7 +113,7 @@ export default async function DashboardPage({ searchParams }) {
               ))}
               {filtered.length === 0 ? (
                 <tr>
-                  <td className="px-8 py-6 text-center text-sm text-slate-400" colSpan={6}>
+                  <td className="px-8 py-6 text-center text-sm text-neutral-400" colSpan={6}>
                     No submissions match the current filters.
                   </td>
                 </tr>
@@ -122,7 +122,7 @@ export default async function DashboardPage({ searchParams }) {
           </table>
         </div>
         {rejected.length ? (
-          <footer className="border-t border-white/10 bg-white/5 px-8 py-5 text-xs text-slate-400">
+          <footer className="border-t border-white/10 bg-white/5 px-8 py-5 text-xs text-neutral-400">
             {rejected.length} request{rejected.length === 1 ? '' : 's'} marked as rejected remain hidden from the projects gallery.
           </footer>
         ) : null}
@@ -133,7 +133,7 @@ export default async function DashboardPage({ searchParams }) {
 
 function MetricCard({ title, value, description, accent }) {
   return (
-    <div className="relative overflow-hidden rounded-[28px] border border-white/10 bg-white/10 p-6 shadow-[0_28px_70px_rgba(9,10,14,0.5)] backdrop-blur-2xl transition duration-300 hover:border-white/20 hover:shadow-[0_34px_88px_rgba(9,10,14,0.58)]">
+    <div className="relative overflow-hidden rounded-[28px] border border-white/10 bg-white/10 p-6 shadow-[0_28px_70px_rgba(0,0,0,0.5)] backdrop-blur-2xl transition duration-300 hover:border-white/20 hover:shadow-[0_34px_88px_rgba(0,0,0,0.58)]">
       <div className={`absolute inset-0 bg-gradient-to-br ${accent}`} aria-hidden="true" />
       <div className="relative space-y-3">
         <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/70">{title}</p>

--- a/app/(app)/layout.jsx
+++ b/app/(app)/layout.jsx
@@ -9,7 +9,7 @@ const navItems = [
 export default function AppLayout({ children }) {
   return (
     <div className="space-y-12">
-      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/[0.05] p-8 shadow-[0_32px_80px_rgba(9,10,15,0.55)] backdrop-blur-2xl">
+      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/[0.05] p-8 shadow-[0_32px_80px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
         <div className="absolute top-[-40%] right-[-20%] h-64 w-64 rounded-full bg-white/10 blur-3xl" aria-hidden="true" />
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(245,245,245,0.14),_transparent_60%)]" aria-hidden="true" />
         <div className="relative flex flex-wrap items-center justify-between gap-8">
@@ -17,13 +17,13 @@ export default function AppLayout({ children }) {
             <div className="flex flex-col gap-1 text-white/70">
               <p className="text-xs font-semibold uppercase tracking-[0.32em] text-primary/70">Studio concierge</p>
               <h1 className="text-3xl font-semibold text-white sm:text-4xl">Client engagement hub</h1>
-              <p className="max-w-xl text-sm text-slate-200/85">
+              <p className="max-w-xl text-sm text-neutral-200/85">
                 Review live initiatives, surface upcoming touchpoints, and keep every brand programme on a single runway.
               </p>
             </div>
             <div className="flex flex-wrap items-center gap-4 text-xs text-white/50">
               <div className="flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-1">
-                <span className="h-2 w-2 rounded-full bg-emerald-400" />
+                <span className="h-2 w-2 rounded-full bg-neutral-200" />
                 <span>Internal workspace</span>
               </div>
               <Link href="/" className="underline">
@@ -31,7 +31,7 @@ export default function AppLayout({ children }) {
               </Link>
             </div>
           </div>
-          <nav className="flex flex-wrap items-center gap-3 rounded-full border border-white/10 bg-white/10 px-2 py-2 text-sm shadow-[0_18px_40px_rgba(9,10,15,0.35)]">
+          <nav className="flex flex-wrap items-center gap-3 rounded-full border border-white/10 bg-white/10 px-2 py-2 text-sm shadow-[0_18px_40px_rgba(0,0,0,0.35)]">
             {navItems.map((item) => (
               <Link
                 key={item.href}

--- a/app/(app)/projects/[id]/page.jsx
+++ b/app/(app)/projects/[id]/page.jsx
@@ -20,7 +20,7 @@ export default async function ProjectPage({ params }) {
 
   return (
     <div className="space-y-12">
-      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/10 p-8 shadow-[0_34px_82px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
+      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/10 p-8 shadow-[0_34px_82px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
         <div className="absolute inset-x-0 top-0 h-32 bg-[radial-gradient(circle_at_top,_rgba(245,245,245,0.14),_transparent_70%)]" aria-hidden="true" />
         <div className="relative flex flex-wrap items-start justify-between gap-8">
           <div className="space-y-4">
@@ -30,7 +30,7 @@ export default async function ProjectPage({ params }) {
               </h1>
               <ProjectTypeBadge type={submission.metadata?.projectType ?? 'other'} />
             </div>
-            <div className="grid gap-2 text-xs text-slate-400 sm:grid-cols-2">
+            <div className="grid gap-2 text-xs text-neutral-400 sm:grid-cols-2">
               <Metadata label="Status" value={<StatusPill status={submission.status} />} asRow={false} />
               <Metadata label="Client" value={submission.metadata?.clientName ?? submission.email} />
               <Metadata label="Investment" value={submission.metadata?.budget ?? '—'} />
@@ -40,7 +40,7 @@ export default async function ProjectPage({ params }) {
           <div className="flex flex-wrap items-center gap-3">
             <Link
               href="/review"
-              className="rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-white/30 hover:text-white"
+              className="rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-neutral-200 transition hover:border-white/30 hover:text-white"
             >
               Open Review Console
             </Link>
@@ -52,12 +52,12 @@ export default async function ProjectPage({ params }) {
       </header>
 
       <section className="grid gap-8 lg:grid-cols-[1.4fr_1fr]">
-        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-slate-200/90 shadow-[0_28px_72px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
+        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
           <h2 className="text-lg font-semibold text-white">Request details</h2>
-          <p className="mt-4 whitespace-pre-line leading-relaxed text-slate-300/90">{submission.details}</p>
+          <p className="mt-4 whitespace-pre-line leading-relaxed text-neutral-300/90">{submission.details}</p>
         </article>
-        <article className="space-y-4 rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-slate-200/90 shadow-[0_28px_72px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
-          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Project metadata</h3>
+        <article className="space-y-4 rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-neutral-400">Project metadata</h3>
           <Metadata label="Company" value={submission.metadata?.company ?? '—'} />
           <Metadata label="Contact" value={submission.email} />
           <Metadata label="Timeline" value={submission.metadata?.timeline ?? '—'} />
@@ -68,8 +68,8 @@ export default async function ProjectPage({ params }) {
       </section>
 
       <section className="grid gap-8 lg:grid-cols-[1.4fr_1fr]">
-        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-slate-200/90 shadow-[0_28px_72px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
-          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Reference links</h3>
+        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-neutral-400">Reference links</h3>
           {Array.isArray(submission.metadata?.references) && submission.metadata.references.length ? (
             <ul className="mt-4 space-y-2">
               {submission.metadata.references.map((file, index) => (
@@ -81,12 +81,12 @@ export default async function ProjectPage({ params }) {
               ))}
             </ul>
           ) : (
-            <p className="mt-4 text-xs text-slate-500">No attachments provided.</p>
+            <p className="mt-4 text-xs text-neutral-500">No attachments provided.</p>
           )}
         </article>
-        <article className="space-y-4 rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0f1014]/95 via-[#121317]/90 to-[#15161b]/95 p-6 text-sm text-slate-200/85 shadow-[0_28px_72px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
-          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Next steps</h3>
-          <ul className="space-y-3 text-sm text-slate-300/90">
+        <article className="space-y-4 rounded-[28px] border border-white/10 bg-gradient-to-br from-black/95 via-neutral-950/90 to-neutral-900/95 p-6 text-sm text-neutral-200/85 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-neutral-400">Next steps</h3>
+          <ul className="space-y-3 text-sm text-neutral-300/90">
             <li className="flex items-start gap-3">
               <CheckCircle className="mt-1 h-4 w-4 text-white/60" />
               <span>Schedule discovery call with {submission.metadata?.clientName ?? 'client'}.</span>
@@ -110,12 +110,12 @@ function Metadata({ label, value, asRow = true }) {
   return (
     <div
       className={clsx(
-        'flex gap-4 text-slate-300/90',
+        'flex gap-4 text-neutral-300/90',
         asRow ? 'items-center justify-between' : 'flex-col items-start'
       )}
     >
-      <span className="text-[11px] uppercase tracking-[0.28em] text-slate-500">{label}</span>
-      <span className="text-sm font-medium text-slate-200">{value || '—'}</span>
+      <span className="text-[11px] uppercase tracking-[0.28em] text-neutral-500">{label}</span>
+      <span className="text-sm font-medium text-neutral-200">{value || '—'}</span>
     </div>
   )
 }

--- a/app/(app)/projects/[id]/plan/page.jsx
+++ b/app/(app)/projects/[id]/plan/page.jsx
@@ -18,13 +18,13 @@ export default async function ProjectPlanPage({ params }) {
     <div className="space-y-10">
       <header className="flex flex-wrap items-center justify-between gap-4">
         <div className="space-y-3">
-          <span className="inline-flex items-center gap-2 rounded-full bg-white/5 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-400">
+          <span className="inline-flex items-center gap-2 rounded-full bg-white/5 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">
             Planning preview
           </span>
           <h1 className="text-3xl font-semibold text-white">
             Plan • {submission.metadata?.projectTitle ?? submission.name}
           </h1>
-          <p className="text-sm text-slate-300/85">
+          <p className="text-sm text-neutral-300/85">
             Automated planning is disabled in this simplified workspace. Enable the agent pipeline to generate milestones, dependencies, and acceptance tests automatically.
           </p>
         </div>
@@ -34,7 +34,7 @@ export default async function ProjectPlanPage({ params }) {
           </button>
           <Link
             href={`/projects/${submission.id}`}
-            className="rounded-full border border-white/15 px-5 py-2 text-sm font-semibold text-slate-200 transition hover:border-white/30 hover:text-white"
+            className="rounded-full border border-white/15 px-5 py-2 text-sm font-semibold text-neutral-200 transition hover:border-white/30 hover:text-white"
           >
             ← Back to Project
           </Link>
@@ -42,9 +42,9 @@ export default async function ProjectPlanPage({ params }) {
       </header>
 
       <section className="grid gap-6 lg:grid-cols-[1.6fr_1fr]">
-        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-slate-200/90 shadow-[0_28px_72px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
+        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
           <h2 className="text-lg font-semibold text-white">Agent capabilities</h2>
-          <ul className="mt-4 space-y-3 text-slate-300/90">
+          <ul className="mt-4 space-y-3 text-neutral-300/90">
             <li className="flex items-start gap-3">
               <span className="mt-1 h-2 w-2 flex-none rounded-full bg-white/60" aria-hidden="true" />
               <p>Synthesizes milestones with dependencies, owners, and testable acceptance criteria.</p>
@@ -59,9 +59,9 @@ export default async function ProjectPlanPage({ params }) {
             </li>
           </ul>
         </article>
-        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-slate-200/90 shadow-[0_28px_72px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
-          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Export brief</h3>
-          <p className="text-sm text-slate-300/85">
+        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-neutral-400">Export brief</h3>
+          <p className="text-sm text-neutral-300/85">
             Download the intake summary to share with stakeholders before agents take over.
           </p>
           <div className="mt-4 flex flex-wrap gap-3">

--- a/app/(app)/projects/page.jsx
+++ b/app/(app)/projects/page.jsx
@@ -17,25 +17,25 @@ export default async function ProjectsPage({ searchParams }) {
     <div className="space-y-10">
       <header className="flex flex-wrap items-start justify-between gap-6">
         <div className="space-y-3">
-          <span className="inline-flex items-center gap-2 rounded-full bg-white/5 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-400">
+          <span className="inline-flex items-center gap-2 rounded-full bg-white/5 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">
             Pipeline overview
           </span>
           <h1 className="text-3xl font-semibold text-white sm:text-4xl">Projects in motion</h1>
-          <p className="max-w-2xl text-sm text-slate-300/90">
+          <p className="max-w-2xl text-sm text-neutral-300/90">
             Accepted and pending submissions appear here as soon as the review team approves them. Drill into each request to see metadata, attachments, and workflow notes.
           </p>
           <Filters filters={filters} />
         </div>
         <Link
           href="/new"
-          className="rounded-full border border-white/15 bg-white/90 px-6 py-2 text-sm font-semibold text-[#111216] shadow-[0_22px_60px_rgba(9,10,14,0.55)] transition hover:bg-white"
+          className="rounded-full border border-white/15 bg-white/90 px-6 py-2 text-sm font-semibold text-[#111216] shadow-[0_22px_60px_rgba(0,0,0,0.55)] transition hover:bg-white"
         >
           + New Engagement
         </Link>
       </header>
 
       {filtered.length === 0 ? (
-        <div className="rounded-[32px] border border-dashed border-white/15 bg-white/5 p-10 text-sm text-slate-400">
+        <div className="rounded-[32px] border border-dashed border-white/15 bg-white/5 p-10 text-sm text-neutral-400">
           No projects match your filters. Adjust filters or submit a new engagement to see it here.
         </div>
       ) : (
@@ -43,7 +43,7 @@ export default async function ProjectsPage({ searchParams }) {
           {filtered.map((submission, index) => (
             <article
               key={submission.id}
-              className="group relative overflow-hidden rounded-[28px] border border-white/10 bg-white/10 p-6 shadow-[0_28px_70px_rgba(9,10,14,0.5)] transition duration-300 hover:border-white/20 hover:shadow-[0_36px_90px_rgba(9,10,14,0.6)]"
+              className="group relative overflow-hidden rounded-[28px] border border-white/10 bg-white/10 p-6 shadow-[0_28px_70px_rgba(0,0,0,0.5)] transition duration-300 hover:border-white/20 hover:shadow-[0_36px_90px_rgba(0,0,0,0.6)]"
             >
               <div className="absolute right-6 top-6 h-12 w-12 rounded-full bg-white/10 blur-2xl opacity-0 transition duration-300 group-hover:opacity-100" aria-hidden="true" />
               <header className="relative flex items-start justify-between gap-4">
@@ -54,19 +54,19 @@ export default async function ProjectsPage({ searchParams }) {
                     </h2>
                     <ProjectTypeBadge type={submission.metadata?.projectType ?? 'other'} />
                   </div>
-                  <div className="flex flex-wrap items-center gap-3 text-xs text-slate-400">
+                  <div className="flex flex-wrap items-center gap-3 text-xs text-neutral-400">
                     <StatusPill status={submission.status} />
                     <span>{submission.metadata?.clientName ?? submission.email}</span>
                     {submission.metadata?.budget ? <span>Investment {submission.metadata.budget}</span> : null}
                     {submission.metadata?.keyMoment ? <span>Key moment {submission.metadata.keyMoment}</span> : null}
                   </div>
                 </div>
-                <span className="rounded-full bg-white/5 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-400">
+                <span className="rounded-full bg-white/5 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-neutral-400">
                   #{index + 1}
                 </span>
               </header>
-              <p className="mt-4 line-clamp-2 text-sm leading-relaxed text-slate-300/90">{submission.details}</p>
-              <div className="mt-4 grid gap-2 text-xs text-slate-400">
+              <p className="mt-4 line-clamp-2 text-sm leading-relaxed text-neutral-300/90">{submission.details}</p>
+              <div className="mt-4 grid gap-2 text-xs text-neutral-400">
                 <div className="flex items-center justify-between">
                   <span>Submitted</span>
                   <span>{formatDate(submission.createdAt)}</span>

--- a/app/(app)/tasks/[id]/page.jsx
+++ b/app/(app)/tasks/[id]/page.jsx
@@ -50,22 +50,22 @@ export default async function TaskPage({ params }) {
 
   return (
     <div className="space-y-12">
-      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/10 p-8 shadow-[0_34px_82px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
+      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/10 p-8 shadow-[0_34px_82px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
         <div className="absolute inset-x-0 top-0 h-28 bg-[radial-gradient(circle_at_top,_rgba(245,245,245,0.14),_transparent_70%)]" aria-hidden="true" />
         <div className="relative flex flex-wrap items-start justify-between gap-6">
           <div className="space-y-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Task</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-400">Task</p>
             <h1 className="text-3xl font-semibold text-white">{task.title}</h1>
-            <p className="text-sm text-slate-300/90">{task.description}</p>
+            <p className="text-sm text-neutral-300/90">{task.description}</p>
             {project ? (
-              <p className="text-xs text-slate-500">
+              <p className="text-xs text-neutral-500">
                 Project:{' '}
                 <Link href={`/projects/${project.id}`} className="text-primary">
                   {project.title}
                 </Link>
               </p>
             ) : null}
-            <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-slate-400">
+            <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-neutral-400">
               <StatusPill status={task.status} />
               {task.assignee ? <span>Assignee: {task.assignee}</span> : null}
               {task.estimate_hours ? <span>Estimate: {task.estimate_hours}h</span> : null}
@@ -81,30 +81,30 @@ export default async function TaskPage({ params }) {
       </header>
 
       <section className="grid gap-8 lg:grid-cols-[1.4fr_1fr]">
-        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-slate-200/90 shadow-[0_28px_72px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
+        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
           <h2 className="text-lg font-semibold text-white">Acceptance Tests</h2>
           {acceptance.length ? (
             <ul className="mt-4 space-y-3">
               {acceptance.map((item) => (
                 <li key={item.id ?? item.description} className="rounded-2xl border border-white/10 bg-white/5 p-4">
                   <p className="font-medium text-white">{item.description}</p>
-                  {item.validation ? <p className="mt-2 text-xs text-slate-400">Validation: {item.validation}</p> : null}
+                  {item.validation ? <p className="mt-2 text-xs text-neutral-400">Validation: {item.validation}</p> : null}
                 </li>
               ))}
             </ul>
           ) : (
-            <p className="mt-4 text-sm text-slate-500">No acceptance tests recorded.</p>
+            <p className="mt-4 text-sm text-neutral-500">No acceptance tests recorded.</p>
           )}
         </article>
-        <article className="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0f1014]/95 via-[#121317]/90 to-[#15161b]/95 p-6 text-sm text-slate-200/85 shadow-[0_28px_72px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
+        <article className="rounded-[28px] border border-white/10 bg-gradient-to-br from-black/95 via-neutral-950/90 to-neutral-900/95 p-6 text-sm text-neutral-200/85 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
           <h2 className="text-lg font-semibold text-white">Agent run log</h2>
-          <p className="mt-3 text-sm text-slate-300/85">
+          <p className="mt-3 text-sm text-neutral-300/85">
             Every run triggers the DevOps runner, QA/Test agent, and auto-repair loop. Completed runs and previews surface below.
           </p>
         </article>
       </section>
 
-      <section className="rounded-[32px] border border-white/10 bg-white/10 p-6 shadow-[0_34px_82px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
+      <section className="rounded-[32px] border border-white/10 bg-white/10 p-6 shadow-[0_34px_82px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
         <h2 className="text-lg font-semibold text-white">Run Timeline</h2>
         <div className="mt-6">
           <RunTimeline runs={runData} />

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,15 +8,15 @@
 
 @layer base {
   body {
-    @apply font-sans bg-[#0f1014] text-[#f5f5f5] antialiased;
-    background-image: radial-gradient(circle at 18% 22%, rgba(245, 245, 245, 0.08), transparent 60%),
-      radial-gradient(circle at 80% 12%, rgba(148, 163, 184, 0.12), transparent 55%),
-      linear-gradient(160deg, rgba(9, 10, 12, 0.96), rgba(15, 16, 20, 0.98));
+    @apply font-sans bg-black text-neutral-100 antialiased;
+    background-image: radial-gradient(circle at 18% 22%, rgba(255, 255, 255, 0.08), transparent 60%),
+      radial-gradient(circle at 80% 12%, rgba(255, 255, 255, 0.06), transparent 55%),
+      linear-gradient(160deg, rgba(0, 0, 0, 0.96), rgba(20, 20, 20, 0.98));
     background-attachment: fixed;
   }
 
   * {
-    @apply selection:bg-primary/30 selection:text-primary-foreground;
+    @apply selection:bg-white/20 selection:text-neutral-900;
   }
 
   h1,
@@ -29,7 +29,7 @@
   }
 
   a {
-    @apply text-primary transition-colors duration-200 hover:text-primary/70;
+    @apply text-neutral-100 transition-colors duration-200 hover:text-neutral-400;
   }
 
   a.underline,
@@ -39,25 +39,25 @@
   }
 
   button {
-    @apply inline-flex items-center justify-center rounded-full border border-white/10 bg-white/90 px-6 py-2 text-sm font-semibold text-[#111216] shadow-[0_14px_40px_rgba(9,10,14,0.45)] transition duration-200 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/40 disabled:cursor-not-allowed disabled:opacity-60;
+    @apply inline-flex items-center justify-center rounded-full border border-neutral-700 bg-neutral-100 px-6 py-2 text-sm font-semibold text-neutral-900 shadow-[0_14px_40px_rgba(0,0,0,0.45)] transition duration-200 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500 disabled:cursor-not-allowed disabled:opacity-60;
   }
 
   input,
   textarea,
   select {
-    @apply rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-100 shadow-inner transition duration-200 placeholder:text-slate-500 focus:border-white/35 focus:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/25;
+    @apply rounded-2xl border border-neutral-800 bg-neutral-900 px-4 py-3 text-sm text-neutral-100 shadow-inner transition duration-200 placeholder:text-neutral-500 focus:border-neutral-500 focus:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-neutral-500/40;
     color-scheme: dark;
   }
 
   select option {
-    @apply bg-slate-900 text-slate-100;
+    @apply bg-neutral-900 text-neutral-100;
   }
 }
 
 @layer components {
   .glass-panel {
-    @apply rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl transition duration-300 hover:border-white/20;
-    box-shadow: 0 10px 55px rgba(10, 11, 15, 0.45);
+    @apply rounded-3xl border border-neutral-800 bg-white/5 p-6 backdrop-blur-xl transition duration-300 hover:border-neutral-600;
+    box-shadow: 0 10px 55px rgba(0, 0, 0, 0.45);
   }
 
   .section-heading {

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -17,7 +17,7 @@ const AuthButtons = dynamic(() => import('../components/AuthButtons'), { ssr: fa
 export default function RootLayout({ children }) {
   return (
     <html lang="en" className="scroll-smooth">
-      <body className={`${sans.variable} ${display.variable} relative min-h-screen overflow-x-hidden bg-slate-950 text-slate-100 antialiased`}>
+      <body className={`${sans.variable} ${display.variable} relative min-h-screen overflow-x-hidden bg-neutral-950 text-neutral-100 antialiased`}>
         <div className="pointer-events-none fixed inset-0 -z-10 bg-aurora opacity-80 blur-3xl" aria-hidden="true" />
         <div className="absolute right-6 top-6 z-20">
           <AuthButtons />

--- a/app/my/[id]/page.jsx
+++ b/app/my/[id]/page.jsx
@@ -27,13 +27,13 @@ export default async function MyProjectDetailsPage({ params }) {
 
   return (
     <div className="space-y-12">
-      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/10 p-8 shadow-[0_34px_82px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
+      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/10 p-8 shadow-[0_34px_82px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
         <div className="absolute inset-x-0 top-0 h-28 bg-[radial-gradient(circle_at_top,_rgba(245,245,245,0.14),_transparent_70%)]" aria-hidden="true" />
         <div className="relative flex flex-wrap items-start justify-between gap-6">
           <div className="space-y-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Your project</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-400">Your project</p>
             <h1 className="text-3xl font-semibold text-white">{submission.metadata?.projectTitle ?? submission.name}</h1>
-            <div className="flex flex-wrap items-center gap-3 text-xs text-slate-400">
+            <div className="flex flex-wrap items-center gap-3 text-xs text-neutral-400">
               <StatusPill status={submission.status} />
               <ProjectTypeBadge type={submission.metadata?.projectType ?? 'other'} />
             </div>
@@ -45,12 +45,12 @@ export default async function MyProjectDetailsPage({ params }) {
       </header>
 
       <section className="grid gap-8 lg:grid-cols-[1.4fr_1fr]">
-        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-slate-200/90 shadow-[0_28px_72px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
+        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
           <h2 className="text-lg font-semibold text-white">Submission details</h2>
-          <p className="mt-4 whitespace-pre-line leading-relaxed text-slate-300/90">{submission.details}</p>
+          <p className="mt-4 whitespace-pre-line leading-relaxed text-neutral-300/90">{submission.details}</p>
         </article>
-        <article className="space-y-4 rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-slate-200/90 shadow-[0_28px_72px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
-          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Project metadata</h3>
+        <article className="space-y-4 rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-neutral-400">Project metadata</h3>
           <Meta label="Email" value={submission.email} />
           <Meta label="Timeline" value={submission.metadata?.timeline ?? '—'} />
           <Meta label="Investment" value={submission.metadata?.budget ?? '—'} />
@@ -60,7 +60,7 @@ export default async function MyProjectDetailsPage({ params }) {
         </article>
       </section>
 
-      <section className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-slate-200/90 shadow-[0_28px_72px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
+      <section className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
         <h2 className="text-lg font-semibold text-white">Reference links</h2>
         {Array.isArray(submission.metadata?.references) && submission.metadata.references.length ? (
           <ul className="mt-4 space-y-2">
@@ -73,7 +73,7 @@ export default async function MyProjectDetailsPage({ params }) {
             ))}
           </ul>
         ) : (
-          <p className="mt-4 text-xs text-slate-500">No reference links provided.</p>
+          <p className="mt-4 text-xs text-neutral-500">No reference links provided.</p>
         )}
       </section>
     </div>
@@ -82,9 +82,9 @@ export default async function MyProjectDetailsPage({ params }) {
 
 function Meta({ label, value }) {
   return (
-    <div className="flex items-center justify-between gap-4 text-slate-300/90">
-      <span className="text-[11px] uppercase tracking-[0.28em] text-slate-500">{label}</span>
-      <span className="text-sm font-medium text-slate-200">{value || '—'}</span>
+    <div className="flex items-center justify-between gap-4 text-neutral-300/90">
+      <span className="text-[11px] uppercase tracking-[0.28em] text-neutral-500">{label}</span>
+      <span className="text-sm font-medium text-neutral-200">{value || '—'}</span>
     </div>
   )
 }

--- a/app/my/page.jsx
+++ b/app/my/page.jsx
@@ -20,13 +20,13 @@ export default async function MyProjectsPage() {
     <div className="space-y-8">
       <header className="space-y-2">
         <h1 className="text-3xl font-semibold text-white">My Projects</h1>
-        <p className="text-sm text-slate-300/85">Signed in as {user.email}</p>
+        <p className="text-sm text-neutral-300/85">Signed in as {user.email}</p>
       </header>
 
       {submissions.length === 0 ? (
-        <div className="rounded-[28px] border border-white/10 bg-white/5 p-8 text-sm text-slate-300/90">
+        <div className="rounded-[28px] border border-white/10 bg-white/5 p-8 text-sm text-neutral-300/90">
           <p>No projects found for your account yet.</p>
-          <p className="mt-3 text-slate-400">
+          <p className="mt-3 text-neutral-400">
             Share your first campaign brief and we&apos;ll keep the status, files, and next steps organised here.
           </p>
           <Link
@@ -39,17 +39,17 @@ export default async function MyProjectsPage() {
       ) : (
         <div className="grid gap-6 md:grid-cols-2">
           {submissions.map((s, index) => (
-            <article key={s.id} className="group rounded-[28px] border border-white/10 bg-white/10 p-6 shadow-[0_28px_70px_rgba(9,10,14,0.5)]">
+            <article key={s.id} className="group rounded-[28px] border border-white/10 bg-white/10 p-6 shadow-[0_28px_70px_rgba(0,0,0,0.5)]">
               <header className="flex items-start justify-between">
                 <h2 className="text-xl font-semibold text-white">{s.metadata?.projectTitle ?? s.name}</h2>
-                <span className="rounded-full bg-white/5 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-400">#{index + 1}</span>
+                <span className="rounded-full bg-white/5 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-neutral-400">#{index + 1}</span>
               </header>
-              <div className="mt-3 flex items-center gap-3 text-xs text-slate-400">
+              <div className="mt-3 flex items-center gap-3 text-xs text-neutral-400">
                 <StatusPill status={s.status} />
                 <span>Submitted {formatDate(s.createdAt)}</span>
               </div>
-              <p className="mt-3 line-clamp-3 text-sm text-slate-300/90">{s.details}</p>
-              <div className="mt-4 text-xs text-slate-400">
+              <p className="mt-3 line-clamp-3 text-sm text-neutral-300/90">{s.details}</p>
+              <div className="mt-4 text-xs text-neutral-400">
                 {s.metadata?.keyMoment ? <p>Key moment: {s.metadata.keyMoment}</p> : null}
               </div>
               <Link href={`/my/${s.id}`} className="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-primary">

--- a/app/review/page.jsx
+++ b/app/review/page.jsx
@@ -76,25 +76,25 @@ export default function ReviewPage() {
 
   return (
     <main className="space-y-10">
-      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/10 p-8 shadow-[0_34px_82px_rgba(9,10,14,0.55)] backdrop-blur-2xl">
+      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/10 p-8 shadow-[0_34px_82px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
         <div className="absolute inset-x-0 top-0 h-28 bg-[radial-gradient(circle_at_top,_rgba(245,245,245,0.14),_transparent_70%)]" aria-hidden="true" />
         <div className="relative space-y-4">
           <span className="inline-flex items-center gap-2 rounded-full bg-primary/15 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-primary/80">
             Review Console
           </span>
           <h1 className="text-3xl font-semibold text-white">Submission Review</h1>
-          <p className="max-w-3xl text-sm text-slate-300/90">
+          <p className="max-w-3xl text-sm text-neutral-300/90">
             Inspect project requests, confirm details, and move them into the delivery pipeline. Approving an item makes it visible on the projects page.
           </p>
         </div>
       </header>
 
-      {loading ? (
-        <p className="text-sm text-slate-400">Loading submissions…</p>
-      ) : error ? (
-        <p className="text-sm text-rose-400">{error}</p>
+        {loading ? (
+          <p className="text-sm text-neutral-400">Loading submissions…</p>
+        ) : error ? (
+          <p className="text-sm text-neutral-300">{error}</p>
       ) : submissions.length === 0 ? (
-        <div className="rounded-[28px] border border-dashed border-white/15 bg-white/5 p-8 text-sm text-slate-400">
+        <div className="rounded-[28px] border border-dashed border-white/15 bg-white/5 p-8 text-sm text-neutral-400">
           No submissions yet. Once requests are submitted, they will appear here for review.
         </div>
       ) : (
@@ -102,7 +102,7 @@ export default function ReviewPage() {
           {submissions.map((submission) => (
             <article
               key={submission.id}
-              className="group relative overflow-hidden rounded-[28px] border border-white/10 bg-white/10 p-6 shadow-[0_28px_72px_rgba(9,10,14,0.55)] transition duration-300 hover:border-white/20 hover:shadow-[0_36px_96px_rgba(9,10,14,0.62)]"
+              className="group relative overflow-hidden rounded-[28px] border border-white/10 bg-white/10 p-6 shadow-[0_28px_72px_rgba(0,0,0,0.55)] transition duration-300 hover:border-white/20 hover:shadow-[0_36px_96px_rgba(0,0,0,0.62)]"
             >
               <div className="absolute right-6 top-6 h-10 w-10 rounded-full bg-white/10 blur-2xl opacity-0 transition duration-300 group-hover:opacity-100" aria-hidden="true" />
               <header className="relative flex flex-wrap items-start justify-between gap-4">
@@ -110,7 +110,7 @@ export default function ReviewPage() {
                   <h2 className="text-lg font-semibold text-white">
                     {submission.metadata?.projectTitle ?? submission.name}
                   </h2>
-                  <p className="text-xs text-slate-400">
+                  <p className="text-xs text-neutral-400">
                     {submission.metadata?.clientName ? `${submission.metadata.clientName} • ` : ''}
                     {submission.email}
                   </p>
@@ -118,15 +118,15 @@ export default function ReviewPage() {
                 <StatusPill status={submission.status} />
               </header>
 
-              <p className="mt-4 whitespace-pre-line text-sm leading-relaxed text-slate-200/90">{submission.details}</p>
+              <p className="mt-4 whitespace-pre-line text-sm leading-relaxed text-neutral-200/90">{submission.details}</p>
 
-              <div className="mt-6 space-y-2 text-xs text-slate-400">
+              <div className="mt-6 space-y-2 text-xs text-neutral-400">
                 {submission.metadata?.projectType ? <p>Project type: {submission.metadata.projectType}</p> : null}
                 {submission.metadata?.budget ? <p>Investment: {submission.metadata.budget}</p> : null}
                 {submission.metadata?.keyMoment ? <p>Key moment: {submission.metadata.keyMoment}</p> : null}
                 {Array.isArray(submission.metadata?.references) && submission.metadata.references.length ? (
                   <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
-                    <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">Reference links</p>
+                    <p className="text-xs font-semibold uppercase tracking-[0.24em] text-neutral-400">Reference links</p>
                     <ul className="mt-2 space-y-1 text-xs">
                       {submission.metadata.references.map((file, index) => (
                         <li key={`${file.url}-${index}`} className="truncate">
@@ -140,7 +140,7 @@ export default function ReviewPage() {
                 ) : null}
               </div>
 
-              <footer className="mt-6 flex flex-wrap items-center gap-4 text-xs text-slate-500">
+              <footer className="mt-6 flex flex-wrap items-center gap-4 text-xs text-neutral-500">
                 <p>Submitted {new Date(submission.createdAt).toLocaleString()}</p>
                 <p>Updated {new Date(submission.updatedAt).toLocaleString()}</p>
               </footer>
@@ -154,12 +154,12 @@ export default function ReviewPage() {
                 >
                   Accept
                 </button>
-                <button
-                  type="button"
-                  disabled={submission.status !== 'pending' || processingId === submission.id}
-                  onClick={() => handleDecision(submission.id, 'rejected')}
-                  className="min-w-[140px] justify-center bg-gradient-to-br from-rose-500/80 via-rose-500/70 to-rose-600/70 text-rose-50 shadow-[0_15px_40px_rgba(244,63,94,0.3)] hover:shadow-[0_20px_60px_rgba(244,63,94,0.4)]"
-                >
+                  <button
+                    type="button"
+                    disabled={submission.status !== 'pending' || processingId === submission.id}
+                    onClick={() => handleDecision(submission.id, 'rejected')}
+                    className="min-w-[140px] justify-center bg-neutral-900 text-neutral-100 shadow-[0_15px_40px_rgba(0,0,0,0.3)] transition hover:bg-neutral-800 hover:shadow-[0_20px_60px_rgba(0,0,0,0.4)]"
+                  >
                   Reject
                 </button>
               </div>
@@ -168,7 +168,7 @@ export default function ReviewPage() {
         </section>
       )}
 
-      {actionError ? <p className="text-sm text-rose-400">{actionError}</p> : null}
+        {actionError ? <p className="text-sm text-neutral-300">{actionError}</p> : null}
     </main>
   )
 }

--- a/components/Editor.jsx
+++ b/components/Editor.jsx
@@ -6,7 +6,7 @@ export function Editor({ initialValue = '', label = 'Notes', onChange = () => {}
   const [value, setValue] = useState(initialValue)
 
   return (
-    <label className="flex flex-col gap-2 text-sm text-slate-300">
+    <label className="flex flex-col gap-2 text-sm text-neutral-300">
       <span className="font-medium">{label}</span>
       <textarea
         value={value}
@@ -15,7 +15,7 @@ export function Editor({ initialValue = '', label = 'Notes', onChange = () => {}
           onChange?.(event.target.value)
         }}
         rows={8}
-        className="min-h-[12rem] w-full rounded-xl border border-slate-800 bg-slate-950/80 p-4 text-sm text-slate-100"
+        className="min-h-[12rem] w-full rounded-xl border border-neutral-800 bg-neutral-950/80 p-4 text-sm text-neutral-100"
         placeholder="Share context, assumptions, or manual updates"
       />
     </label>

--- a/components/IntakeForm.jsx
+++ b/components/IntakeForm.jsx
@@ -463,12 +463,12 @@ export function IntakeForm() {
           <div className="flex items-center gap-3">
             <div className="flex flex-col items-start gap-1 text-left">
               {authRequired ? (
-                <div className="text-xs text-amber-300">
-                  <p className="font-semibold text-amber-200">Sign in required</p>
+                <div className="text-xs text-neutral-300">
+                  <p className="font-semibold text-neutral-200">Sign in required</p>
                   <p>We saved your answers. Please sign in to submit your request.</p>
                 </div>
               ) : null}
-              {error ? <p className="text-sm text-rose-400">{error}</p> : null}
+                {error ? <p className="text-sm text-neutral-300">{error}</p> : null}
             </div>
             <div className="flex items-center gap-2">
               {step > 0 ? (
@@ -505,14 +505,14 @@ export function IntakeForm() {
       </form>
 
       {authRequired ? (
-        <div className="rounded-[28px] border border-amber-500/30 bg-amber-500/10 p-6 text-sm text-amber-100">
+        <div className="rounded-[28px] border border-neutral-500/30 bg-neutral-500/10 p-6 text-sm text-neutral-100">
           <p className="font-semibold">Almost there — sign in to continue.</p>
-          <p className="mt-2 text-amber-200/80">
+          <p className="mt-2 text-neutral-200/80">
             We&apos;ve preserved your responses. Sign in below to submit without re-entering any details.
           </p>
           <Link
             href={signInHref}
-            className="mt-4 inline-flex items-center justify-center rounded-full bg-amber-400 px-5 py-2 text-sm font-semibold text-[#111216] hover:bg-amber-300"
+            className="mt-4 inline-flex items-center justify-center rounded-full bg-neutral-200 px-5 py-2 text-sm font-semibold text-[#111216] hover:bg-neutral-300"
           >
             Sign in and finish submission
           </Link>
@@ -543,7 +543,7 @@ export function IntakeForm() {
             </div>
             <div className="space-y-2 text-xs text-white/60">
               <p className="font-semibold text-white">Campaign narrative</p>
-              <div className="max-h-48 overflow-auto rounded-2xl border border-white/8 bg-[#0b0c10] p-4 text-[11px] leading-relaxed">
+              <div className="max-h-48 overflow-auto rounded-2xl border border-white/8 bg-[#080808] p-4 text-[11px] leading-relaxed">
                 {submission.details}
               </div>
             </div>
@@ -573,7 +573,7 @@ export function IntakeForm() {
 
 function FormBlock({ title, description, children }) {
   return (
-    <section className="rounded-[28px] border border-white/10 bg-white/5 p-8 shadow-[0_28px_72px_rgba(9,10,14,0.5)] backdrop-blur-2xl">
+    <section className="rounded-[28px] border border-white/10 bg-white/5 p-8 shadow-[0_28px_72px_rgba(0,0,0,0.5)] backdrop-blur-2xl">
       <header className="space-y-2">
         <h2 className="text-xl font-semibold text-white">{title}</h2>
         <p className="text-sm text-white/60">{description}</p>
@@ -589,7 +589,7 @@ function Field({ label, hint, children, required, error }) {
       ? cloneElement(children, {
           className: clsx(
             'w-full',
-            error ? 'border-rose-500/60 focus:border-rose-400/70 focus:ring-rose-400/30' : '',
+              error ? 'border-neutral-500/60 focus:border-neutral-400/70 focus:ring-neutral-400/30' : '',
             children.props.className
           )
         })
@@ -611,7 +611,7 @@ function Field({ label, hint, children, required, error }) {
         )}
       </div>
       {control}
-      {error ? <span className="text-xs text-rose-400">{error}</span> : null}
+        {error ? <span className="text-xs text-neutral-300">{error}</span> : null}
     </label>
   )
 }
@@ -739,11 +739,11 @@ function FileUploadField({ label, hint, value, onChange, multiple = true, requir
             {value.map((file, index) => (
               <li key={`${file.name}-${index}`} className="flex items-center justify-between gap-3">
                 <span className="truncate">{file.name}</span>
-                <button
-                  type="button"
-                  onClick={() => removeFile(index)}
-                  className="text-rose-300 hover:text-rose-200"
-                >
+                  <button
+                    type="button"
+                    onClick={() => removeFile(index)}
+                    className="text-neutral-300 hover:text-neutral-200"
+                  >
                   Remove
                 </button>
               </li>
@@ -753,7 +753,7 @@ function FileUploadField({ label, hint, value, onChange, multiple = true, requir
           <p className="text-xs text-white/50">No files added yet.</p>
         )}
       </div>
-      {error ? <span className="text-xs text-rose-400">{error}</span> : null}
+        {error ? <span className="text-xs text-neutral-300">{error}</span> : null}
     </div>
   )
 }

--- a/components/PlanTree.jsx
+++ b/components/PlanTree.jsx
@@ -1,38 +1,38 @@
 export function PlanTree({ milestones }) {
   if (!milestones.length) {
-    return <p className="text-sm text-slate-400">Plan not generated yet.</p>
+    return <p className="text-sm text-neutral-400">Plan not generated yet.</p>
   }
 
   return (
     <div className="space-y-6">
       {milestones.map((milestone) => (
-        <section key={milestone.id} className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
+        <section key={milestone.id} className="space-y-4 rounded-2xl border border-neutral-800 bg-neutral-900/40 p-5">
           <header>
             <h3 className="text-lg font-semibold text-white">{milestone.name}</h3>
-            {milestone.summary ? <p className="text-sm text-slate-400">{milestone.summary}</p> : null}
+            {milestone.summary ? <p className="text-sm text-neutral-400">{milestone.summary}</p> : null}
           </header>
           <ol className="space-y-3">
             {milestone.tasks.map((task) => (
-              <li key={task.id} className="space-y-2 rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+              <li key={task.id} className="space-y-2 rounded-xl border border-neutral-800 bg-neutral-950/70 p-4">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <p className="text-sm font-medium text-white">{task.title}</p>
                   {task.dependencies?.length ? (
-                    <span className="text-[11px] uppercase tracking-wide text-slate-500">
+                    <span className="text-[11px] uppercase tracking-wide text-neutral-500">
                       Depends on: {task.dependencies.join(', ')}
                     </span>
                   ) : null}
                 </div>
                 {task.description ? (
-                  <p className="text-sm text-slate-400">{task.description}</p>
+                  <p className="text-sm text-neutral-400">{task.description}</p>
                 ) : null}
                 {task.acceptance?.length ? (
-                  <ul className="space-y-1 text-xs text-slate-500">
+                  <ul className="space-y-1 text-xs text-neutral-500">
                     {task.acceptance.map((acceptance) => (
                       <li key={acceptance.id}>• {acceptance.description}</li>
                     ))}
                   </ul>
                 ) : (
-                  <p className="text-xs text-slate-600">No acceptance tests yet.</p>
+                  <p className="text-xs text-neutral-600">No acceptance tests yet.</p>
                 )}
               </li>
             ))}

--- a/components/RunTimeline.jsx
+++ b/components/RunTimeline.jsx
@@ -3,23 +3,23 @@ import { formatDistanceToNow } from 'date-fns'
 
 export function RunTimeline({ runs }) {
   if (!runs.length) {
-    return <p className="text-sm text-slate-400">No runs yet.</p>
+    return <p className="text-sm text-neutral-400">No runs yet.</p>
   }
 
   return (
-    <ol className="space-y-4 border-l border-slate-800 pl-6">
+    <ol className="space-y-4 border-l border-neutral-800 pl-6">
       {runs.map((run) => (
         <li key={run.id} className="relative">
           <span className="absolute -left-[11px] top-2 h-3 w-3 rounded-full bg-primary"></span>
-          <div className="flex flex-col gap-2 rounded-xl border border-slate-800 bg-slate-900/40 p-4">
+          <div className="flex flex-col gap-2 rounded-xl border border-neutral-800 bg-neutral-900/40 p-4">
             <div className="flex flex-wrap items-center gap-3">
               <h4 className="text-sm font-semibold text-white">Attempt {run.attempt + 1}</h4>
               <StatusPill status={run.state} />
-              <span className="text-xs text-slate-500">
+              <span className="text-xs text-neutral-500">
                 {run.createdAt ? formatDistanceToNow(new Date(run.createdAt), { addSuffix: true }) : '—'}
               </span>
             </div>
-            <div className="flex flex-wrap gap-3 text-xs text-slate-400">
+            <div className="flex flex-wrap gap-3 text-xs text-neutral-400">
               {run.ciUrl ? (
                 <a href={run.ciUrl} className="hover:text-white" target="_blank" rel="noreferrer">
                   CI Logs
@@ -37,15 +37,15 @@ export function RunTimeline({ runs }) {
               ) : null}
             </div>
             {run.logs ? (
-              <details className="rounded-lg border border-slate-800 bg-slate-950 p-3 text-xs text-slate-400">
-                <summary className="cursor-pointer font-semibold text-slate-300">Logs</summary>
-                <pre className="mt-2 whitespace-pre-wrap text-[11px] leading-relaxed text-slate-400">
+              <details className="rounded-lg border border-neutral-800 bg-neutral-950 p-3 text-xs text-neutral-400">
+                <summary className="cursor-pointer font-semibold text-neutral-300">Logs</summary>
+                <pre className="mt-2 whitespace-pre-wrap text-[11px] leading-relaxed text-neutral-400">
                   {run.logs}
                 </pre>
               </details>
             ) : null}
             {run.result ? (
-              <pre className="overflow-auto rounded-lg border border-slate-800 bg-slate-950 p-3 text-xs text-slate-400">
+              <pre className="overflow-auto rounded-lg border border-neutral-800 bg-neutral-950 p-3 text-xs text-neutral-400">
                 {JSON.stringify(run.result, null, 2)}
               </pre>
             ) : null}

--- a/components/SignInForm.jsx
+++ b/components/SignInForm.jsx
@@ -182,8 +182,8 @@ export function SignInForm({ audience = 'client' }) {
         </form>
       ) : null}
 
-      {error ? <p className="text-sm text-rose-400">{error}</p> : null}
-      {message ? <p className="text-sm text-emerald-400/90">{message}</p> : null}
+      {error ? <p className="text-sm text-neutral-300">{error}</p> : null}
+      {message ? <p className="text-sm text-neutral-200/90">{message}</p> : null}
     </div>
   )
 }

--- a/components/StatusPill.jsx
+++ b/components/StatusPill.jsx
@@ -6,11 +6,11 @@ const statusStyles = {
   estimated: 'bg-white/10 text-white/90',
   executing: 'bg-white/10 text-white/90',
   review: 'bg-white/12 text-white/90',
-  done: 'bg-white text-[#111216]',
-  blocked: 'bg-[#2a1a1a] text-white/90',
+  done: 'bg-white text-neutral-900',
+  blocked: 'bg-neutral-900 text-neutral-200',
   pending: 'bg-white/10 text-white/90',
   accepted: 'bg-white/12 text-white/90',
-  rejected: 'bg-[#2a1a1a] text-white/90'
+  rejected: 'bg-neutral-900 text-neutral-200'
 }
 
 export function StatusPill({ status }) {

--- a/components/TaskBoard.jsx
+++ b/components/TaskBoard.jsx
@@ -35,22 +35,22 @@ export function TaskBoard({ tasks }) {
   return (
     <div className="grid gap-4 md:grid-cols-5">
       {columns.map((column) => (
-        <section key={column.status} className="flex min-h-[18rem] flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-900/40 p-4">
+        <section key={column.status} className="flex min-h-[18rem] flex-col gap-3 rounded-2xl border border-neutral-800 bg-neutral-900/40 p-4">
           <header className="flex items-center justify-between">
-            <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-300">
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-300">
               {column.title}
             </h3>
-            <span className="text-xs text-slate-500">{grouped[column.status]?.length ?? 0}</span>
+            <span className="text-xs text-neutral-500">{grouped[column.status]?.length ?? 0}</span>
           </header>
           <div className="flex-1 space-y-3">
             {(grouped[column.status] ?? []).map((task) => (
-              <article key={task.id} className="space-y-2 rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+              <article key={task.id} className="space-y-2 rounded-xl border border-neutral-800 bg-neutral-900/60 p-3">
                 <div className="flex items-center justify-between gap-3">
                   <p className="text-sm font-medium text-white">{task.title}</p>
                   <StatusPill status={task.status} />
                 </div>
                 {task.description ? (
-                  <p className="text-xs text-slate-400">{task.description}</p>
+                  <p className="text-xs text-neutral-400">{task.description}</p>
                 ) : null}
                 <StatusPicker
                   value={task.status}
@@ -69,12 +69,12 @@ export function TaskBoard({ tasks }) {
                   disabled={isPending}
                 />
                 {task.acceptance?.length ? (
-                  <ul className="space-y-1 text-xs text-slate-500">
+                  <ul className="space-y-1 text-xs text-neutral-500">
                     {task.acceptance.slice(0, 2).map((test) => (
                       <li key={test.id ?? test.description}>✓ {test.description}</li>
                     ))}
                     {task.acceptance.length > 2 ? (
-                      <li className="text-[10px] uppercase text-slate-600">
+                      <li className="text-[10px] uppercase text-neutral-600">
                         +{task.acceptance.length - 2} more tests
                       </li>
                     ) : null}
@@ -91,10 +91,10 @@ export function TaskBoard({ tasks }) {
 
 function StatusPicker({ value, onChange, disabled }) {
   return (
-    <label className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-slate-500">
+    <label className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-neutral-500">
       Status
       <select
-        className="rounded-lg border border-slate-800 bg-slate-950 px-2 py-1 text-[11px] text-slate-200"
+        className="rounded-lg border border-neutral-800 bg-neutral-950 px-2 py-1 text-[11px] text-neutral-200"
         value={value}
         onChange={(event) => onChange(event.target.value)}
         disabled={disabled}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -10,15 +10,15 @@ const config = {
       colors: {
         primary: {
           DEFAULT: '#f5f5f5',
-          foreground: '#111216'
+          foreground: '#090909'
         },
         accent: {
-          DEFAULT: '#e5e7eb',
-          muted: '#f4f4f5'
+          DEFAULT: '#d4d4d4',
+          muted: '#e5e5e5'
         },
-        success: '#16a34a',
-        warning: '#f59e0b',
-        danger: '#dc2626'
+        success: '#d1d5db',
+        warning: '#a3a3a3',
+        danger: '#525252'
       },
       fontFamily: {
         sans: ['var(--font-sans)', 'system-ui', 'sans-serif'],
@@ -26,7 +26,7 @@ const config = {
       },
       backgroundImage: {
         aurora:
-          'radial-gradient(circle at 22% 24%, rgba(245,245,245,0.18), transparent 60%), radial-gradient(circle at 78% 12%, rgba(148,163,184,0.22), transparent 55%), radial-gradient(circle at 52% 82%, rgba(100,116,139,0.18), transparent 58%)'
+          'radial-gradient(circle at 22% 24%, rgba(255,255,255,0.18), transparent 60%), radial-gradient(circle at 78% 12%, rgba(255,255,255,0.14), transparent 55%), radial-gradient(circle at 52% 82%, rgba(255,255,255,0.12), transparent 58%)'
       },
       boxShadow: {
         glow: '0 0 40px rgba(15, 16, 20, 0.45)'


### PR DESCRIPTION
## Summary
- restyled global typography, background, and form controls to a monochrome palette and updated Tailwind theme tokens accordingly
- replaced remaining component-level color accents and gradients with grayscale treatments, including status pills and review actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dbb45223048333882935e147ebbd78