### PR TITLE
Refine intake highlights and simplify monochrome styling

### DIFF
--- a/app/(app)/dashboard/page.jsx
+++ b/app/(app)/dashboard/page.jsx
@@ -22,27 +22,12 @@ export default async function DashboardPage({ searchParams }) {
   return (
     <div className="space-y-12">
       <section className="grid gap-6 md:grid-cols-3">
-        <MetricCard
-          title="Active engagements"
-          value={total}
-          description="Briefs currently in motion"
-          accent="from-white/18 via-white/8 to-transparent"
-        />
-        <MetricCard
-          title="Awaiting review"
-          value={pending.length}
-          description="Discovery call or scope confirmation"
-          accent="from-white/14 via-white/6 to-transparent"
-        />
-        <MetricCard
-          title="Greenlit"
-          value={accepted.length}
-          description="Moving through production and launch"
-          accent="from-white/16 via-white/7 to-transparent"
-        />
+        <MetricCard title="Active engagements" value={total} description="Briefs currently in motion" />
+        <MetricCard title="Awaiting review" value={pending.length} description="Discovery call or scope confirmation" />
+        <MetricCard title="Greenlit" value={accepted.length} description="Moving through production and launch" />
       </section>
 
-      <section className="overflow-hidden rounded-[32px] border border-white/10 bg-white/10 shadow-[0_34px_82px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+      <section className="overflow-hidden rounded-[32px] border border-white/10 bg-neutral-900 shadow-[0_34px_82px_rgba(0,0,0,0.55)]">
         <header className="flex flex-wrap items-center justify-between gap-4 border-b border-white/10 px-8 py-6">
           <div className="space-y-2">
             <h2 className="text-lg font-semibold text-white">Submission portfolio</h2>
@@ -51,14 +36,14 @@ export default async function DashboardPage({ searchParams }) {
           </div>
           <Link
             href="/new"
-            className="rounded-full border border-white/15 bg-white/90 px-5 py-2 text-sm font-semibold text-[#111216] transition hover:bg-white"
+            className="rounded-full border border-white/15 bg-white px-5 py-2 text-sm font-semibold text-black transition hover:bg-neutral-100"
           >
             + New Engagement
           </Link>
         </header>
         <div className="overflow-x-auto">
           <table className="min-w-full divide-y divide-white/12">
-            <thead className="bg-white/10 text-xs uppercase tracking-[0.28em] text-white/70">
+            <thead className="bg-black text-xs uppercase tracking-[0.28em] text-white/70">
               <tr>
                 <th className="px-8 py-4 text-left">Project</th>
                 <th className="px-8 py-4 text-left">Type</th>
@@ -70,7 +55,7 @@ export default async function DashboardPage({ searchParams }) {
             </thead>
             <tbody className="divide-y divide-white/8 text-sm text-neutral-200/85">
               {filtered.map((submission) => (
-                <tr key={submission.id} className="transition duration-200 hover:bg-white/[0.06]">
+                <tr key={submission.id} className="transition duration-200 hover:bg-white/10">
                   <td className="px-8 py-5">
                     <Link className="font-semibold text-white hover:text-primary" href={`/projects/${submission.id}`}>
                       {submission.metadata?.projectTitle ?? submission.name}
@@ -97,13 +82,13 @@ export default async function DashboardPage({ searchParams }) {
                     <div className="flex flex-wrap gap-2">
                       <Link
                         href={`/projects/${submission.id}`}
-                        className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-semibold text-white/70 transition hover:bg-white/20 hover:text-white"
+                        className="rounded-full border border-white/15 bg-black px-3 py-1 text-xs font-semibold text-white/80 transition hover:bg-white hover:text-black"
                       >
                         Review
                       </Link>
                       <Link
                         href={`/projects/${submission.id}/plan`}
-                        className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-semibold text-white/70 transition hover:bg-white/20 hover:text-white"
+                        className="rounded-full border border-white/15 bg-black px-3 py-1 text-xs font-semibold text-white/80 transition hover:bg-white hover:text-black"
                       >
                         Open Plan
                       </Link>
@@ -122,7 +107,7 @@ export default async function DashboardPage({ searchParams }) {
           </table>
         </div>
         {rejected.length ? (
-          <footer className="border-t border-white/10 bg-white/5 px-8 py-5 text-xs text-neutral-400">
+          <footer className="border-t border-white/10 bg-black px-8 py-5 text-xs text-neutral-400">
             {rejected.length} request{rejected.length === 1 ? '' : 's'} marked as rejected remain hidden from the projects gallery.
           </footer>
         ) : null}
@@ -131,15 +116,12 @@ export default async function DashboardPage({ searchParams }) {
   )
 }
 
-function MetricCard({ title, value, description, accent }) {
+function MetricCard({ title, value, description }) {
   return (
-    <div className="relative overflow-hidden rounded-[28px] border border-white/10 bg-white/10 p-6 shadow-[0_28px_70px_rgba(0,0,0,0.5)] backdrop-blur-2xl transition duration-300 hover:border-white/20 hover:shadow-[0_34px_88px_rgba(0,0,0,0.58)]">
-      <div className={`absolute inset-0 bg-gradient-to-br ${accent}`} aria-hidden="true" />
-      <div className="relative space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/70">{title}</p>
-        <p className="text-4xl font-semibold text-white">{value}</p>
-        <p className="text-xs text-white/60">{description}</p>
-      </div>
+    <div className="overflow-hidden rounded-[28px] border border-white/10 bg-neutral-900 p-6 shadow-[0_28px_70px_rgba(0,0,0,0.5)] transition duration-300 hover:border-white/20 hover:shadow-[0_34px_88px_rgba(0,0,0,0.58)]">
+      <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/70">{title}</p>
+      <p className="text-4xl font-semibold text-white">{value}</p>
+      <p className="text-xs text-white/60">{description}</p>
     </div>
   )
 }
@@ -168,7 +150,7 @@ function Filters({ filters }) {
         <option value="Launch strategy">Launch strategy</option>
         <option value="other">Other</option>
       </select>
-      <button type="submit" className="rounded-full border border-white/15 bg-white/10 px-3 py-2 text-white/70">
+      <button type="submit" className="rounded-full border border-white/15 bg-black px-3 py-2 text-white/80">
         Apply
       </button>
     </form>

--- a/app/(app)/layout.jsx
+++ b/app/(app)/layout.jsx
@@ -9,10 +9,8 @@ const navItems = [
 export default function AppLayout({ children }) {
   return (
     <div className="space-y-12">
-      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/[0.05] p-8 shadow-[0_32px_80px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
-        <div className="absolute top-[-40%] right-[-20%] h-64 w-64 rounded-full bg-white/10 blur-3xl" aria-hidden="true" />
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(245,245,245,0.14),_transparent_60%)]" aria-hidden="true" />
-        <div className="relative flex flex-wrap items-center justify-between gap-8">
+      <header className="rounded-[32px] border border-white/10 bg-neutral-900 p-8 shadow-[0_32px_80px_rgba(0,0,0,0.55)]">
+        <div className="flex flex-wrap items-center justify-between gap-8">
           <div className="space-y-3">
             <div className="flex flex-col gap-1 text-white/70">
               <p className="text-xs font-semibold uppercase tracking-[0.32em] text-primary/70">Studio concierge</p>
@@ -31,12 +29,12 @@ export default function AppLayout({ children }) {
               </Link>
             </div>
           </div>
-          <nav className="flex flex-wrap items-center gap-3 rounded-full border border-white/10 bg-white/10 px-2 py-2 text-sm shadow-[0_18px_40px_rgba(0,0,0,0.35)]">
+          <nav className="flex flex-wrap items-center gap-3 rounded-full border border-white/20 bg-black px-2 py-2 text-sm shadow-[0_18px_40px_rgba(0,0,0,0.35)]">
             {navItems.map((item) => (
               <Link
                 key={item.href}
                 href={item.href}
-                className="inline-flex items-center rounded-full px-4 py-2 font-medium text-white/80 transition hover:bg-white/20 hover:text-white"
+                className="inline-flex items-center rounded-full px-4 py-2 font-medium text-white/80 transition hover:bg-white hover:text-black"
               >
                 {item.label}
               </Link>

--- a/app/(app)/projects/[id]/page.jsx
+++ b/app/(app)/projects/[id]/page.jsx
@@ -20,9 +20,8 @@ export default async function ProjectPage({ params }) {
 
   return (
     <div className="space-y-12">
-      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/10 p-8 shadow-[0_34px_82px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
-        <div className="absolute inset-x-0 top-0 h-32 bg-[radial-gradient(circle_at_top,_rgba(245,245,245,0.14),_transparent_70%)]" aria-hidden="true" />
-        <div className="relative flex flex-wrap items-start justify-between gap-8">
+      <header className="rounded-[32px] border border-white/10 bg-neutral-900 p-8 shadow-[0_34px_82px_rgba(0,0,0,0.55)]">
+        <div className="flex flex-wrap items-start justify-between gap-8">
           <div className="space-y-4">
             <div className="flex flex-wrap items-center gap-3">
               <h1 className="text-3xl font-semibold text-white sm:text-4xl">
@@ -52,11 +51,11 @@ export default async function ProjectPage({ params }) {
       </header>
 
       <section className="grid gap-8 lg:grid-cols-[1.4fr_1fr]">
-        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+        <article className="rounded-[28px] border border-white/10 bg-neutral-900 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)]">
           <h2 className="text-lg font-semibold text-white">Request details</h2>
           <p className="mt-4 whitespace-pre-line leading-relaxed text-neutral-300/90">{submission.details}</p>
         </article>
-        <article className="space-y-4 rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+        <article className="space-y-4 rounded-[28px] border border-white/10 bg-neutral-900 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)]">
           <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-neutral-400">Project metadata</h3>
           <Metadata label="Company" value={submission.metadata?.company ?? '—'} />
           <Metadata label="Contact" value={submission.email} />
@@ -68,7 +67,7 @@ export default async function ProjectPage({ params }) {
       </section>
 
       <section className="grid gap-8 lg:grid-cols-[1.4fr_1fr]">
-        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+        <article className="rounded-[28px] border border-white/10 bg-neutral-900 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)]">
           <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-neutral-400">Reference links</h3>
           {Array.isArray(submission.metadata?.references) && submission.metadata.references.length ? (
             <ul className="mt-4 space-y-2">
@@ -84,7 +83,7 @@ export default async function ProjectPage({ params }) {
             <p className="mt-4 text-xs text-neutral-500">No attachments provided.</p>
           )}
         </article>
-        <article className="space-y-4 rounded-[28px] border border-white/10 bg-gradient-to-br from-black/95 via-neutral-950/90 to-neutral-900/95 p-6 text-sm text-neutral-200/85 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+        <article className="space-y-4 rounded-[28px] border border-white/10 bg-neutral-900 p-6 text-sm text-neutral-200/85 shadow-[0_28px_72px_rgba(0,0,0,0.55)]">
           <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-neutral-400">Next steps</h3>
           <ul className="space-y-3 text-sm text-neutral-300/90">
             <li className="flex items-start gap-3">

--- a/app/(app)/projects/page.jsx
+++ b/app/(app)/projects/page.jsx
@@ -17,7 +17,7 @@ export default async function ProjectsPage({ searchParams }) {
     <div className="space-y-10">
       <header className="flex flex-wrap items-start justify-between gap-6">
         <div className="space-y-3">
-          <span className="inline-flex items-center gap-2 rounded-full bg-white/5 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">
+          <span className="inline-flex items-center gap-2 rounded-full bg-black px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-neutral-400">
             Pipeline overview
           </span>
           <h1 className="text-3xl font-semibold text-white sm:text-4xl">Projects in motion</h1>
@@ -28,14 +28,14 @@ export default async function ProjectsPage({ searchParams }) {
         </div>
         <Link
           href="/new"
-          className="rounded-full border border-white/15 bg-white/90 px-6 py-2 text-sm font-semibold text-[#111216] shadow-[0_22px_60px_rgba(0,0,0,0.55)] transition hover:bg-white"
+          className="rounded-full border border-white/15 bg-white px-6 py-2 text-sm font-semibold text-black shadow-[0_22px_60px_rgba(0,0,0,0.55)] transition hover:bg-neutral-100"
         >
           + New Engagement
         </Link>
       </header>
 
       {filtered.length === 0 ? (
-        <div className="rounded-[32px] border border-dashed border-white/15 bg-white/5 p-10 text-sm text-neutral-400">
+        <div className="rounded-[32px] border border-dashed border-white/15 bg-neutral-900 p-10 text-sm text-neutral-400">
           No projects match your filters. Adjust filters or submit a new engagement to see it here.
         </div>
       ) : (
@@ -43,9 +43,8 @@ export default async function ProjectsPage({ searchParams }) {
           {filtered.map((submission, index) => (
             <article
               key={submission.id}
-              className="group relative overflow-hidden rounded-[28px] border border-white/10 bg-white/10 p-6 shadow-[0_28px_70px_rgba(0,0,0,0.5)] transition duration-300 hover:border-white/20 hover:shadow-[0_36px_90px_rgba(0,0,0,0.6)]"
+              className="group overflow-hidden rounded-[28px] border border-white/10 bg-neutral-900 p-6 shadow-[0_28px_70px_rgba(0,0,0,0.5)] transition duration-300 hover:border-white/20 hover:shadow-[0_36px_90px_rgba(0,0,0,0.6)]"
             >
-              <div className="absolute right-6 top-6 h-12 w-12 rounded-full bg-white/10 blur-2xl opacity-0 transition duration-300 group-hover:opacity-100" aria-hidden="true" />
               <header className="relative flex items-start justify-between gap-4">
                 <div className="space-y-3">
                   <div className="flex items-center gap-3">
@@ -61,7 +60,7 @@ export default async function ProjectsPage({ searchParams }) {
                     {submission.metadata?.keyMoment ? <span>Key moment {submission.metadata.keyMoment}</span> : null}
                   </div>
                 </div>
-                <span className="rounded-full bg-white/5 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-neutral-400">
+                <span className="rounded-full bg-black px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-neutral-400">
                   #{index + 1}
                 </span>
               </header>
@@ -105,7 +104,7 @@ function Filters({ filters }) {
         <option value="Launch strategy">Launch strategy</option>
         <option value="other">Other</option>
       </select>
-      <button type="submit" className="rounded-full border border-white/15 bg-white/10 px-3 py-2 text-white/70">
+      <button type="submit" className="rounded-full border border-white/15 bg-black px-3 py-2 text-white/80">
         Apply
       </button>
     </form>

--- a/app/(app)/tasks/[id]/page.jsx
+++ b/app/(app)/tasks/[id]/page.jsx
@@ -50,9 +50,8 @@ export default async function TaskPage({ params }) {
 
   return (
     <div className="space-y-12">
-      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/10 p-8 shadow-[0_34px_82px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
-        <div className="absolute inset-x-0 top-0 h-28 bg-[radial-gradient(circle_at_top,_rgba(245,245,245,0.14),_transparent_70%)]" aria-hidden="true" />
-        <div className="relative flex flex-wrap items-start justify-between gap-6">
+      <header className="rounded-[32px] border border-white/10 bg-neutral-900 p-8 shadow-[0_34px_82px_rgba(0,0,0,0.55)]">
+        <div className="flex flex-wrap items-start justify-between gap-6">
           <div className="space-y-3">
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-400">Task</p>
             <h1 className="text-3xl font-semibold text-white">{task.title}</h1>
@@ -81,7 +80,7 @@ export default async function TaskPage({ params }) {
       </header>
 
       <section className="grid gap-8 lg:grid-cols-[1.4fr_1fr]">
-        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+        <article className="rounded-[28px] border border-white/10 bg-neutral-900 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)]">
           <h2 className="text-lg font-semibold text-white">Acceptance Tests</h2>
           {acceptance.length ? (
             <ul className="mt-4 space-y-3">
@@ -96,7 +95,7 @@ export default async function TaskPage({ params }) {
             <p className="mt-4 text-sm text-neutral-500">No acceptance tests recorded.</p>
           )}
         </article>
-        <article className="rounded-[28px] border border-white/10 bg-gradient-to-br from-black/95 via-neutral-950/90 to-neutral-900/95 p-6 text-sm text-neutral-200/85 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+        <article className="rounded-[28px] border border-white/10 bg-neutral-900 p-6 text-sm text-neutral-200/85 shadow-[0_28px_72px_rgba(0,0,0,0.55)]">
           <h2 className="text-lg font-semibold text-white">Agent run log</h2>
           <p className="mt-3 text-sm text-neutral-300/85">
             Every run triggers the DevOps runner, QA/Test agent, and auto-repair loop. Completed runs and previews surface below.
@@ -104,7 +103,7 @@ export default async function TaskPage({ params }) {
         </article>
       </section>
 
-      <section className="rounded-[32px] border border-white/10 bg-white/10 p-6 shadow-[0_34px_82px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+      <section className="rounded-[32px] border border-white/10 bg-neutral-900 p-6 shadow-[0_34px_82px_rgba(0,0,0,0.55)]">
         <h2 className="text-lg font-semibold text-white">Run Timeline</h2>
         <div className="mt-6">
           <RunTimeline runs={runData} />

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,10 +9,7 @@
 @layer base {
   body {
     @apply font-sans bg-black text-neutral-100 antialiased;
-    background-image: radial-gradient(circle at 18% 22%, rgba(255, 255, 255, 0.08), transparent 60%),
-      radial-gradient(circle at 80% 12%, rgba(255, 255, 255, 0.06), transparent 55%),
-      linear-gradient(160deg, rgba(0, 0, 0, 0.96), rgba(20, 20, 20, 0.98));
-    background-attachment: fixed;
+    background-color: #000;
   }
 
   * {

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -17,12 +17,10 @@ const AuthButtons = dynamic(() => import('../components/AuthButtons'), { ssr: fa
 export default function RootLayout({ children }) {
   return (
     <html lang="en" className="scroll-smooth">
-      <body className={`${sans.variable} ${display.variable} relative min-h-screen overflow-x-hidden bg-neutral-950 text-neutral-100 antialiased`}>
-        <div className="pointer-events-none fixed inset-0 -z-10 bg-aurora opacity-80 blur-3xl" aria-hidden="true" />
+      <body className={`${sans.variable} ${display.variable} relative min-h-screen overflow-x-hidden bg-black text-neutral-100 antialiased`}>
         <div className="absolute right-6 top-6 z-20">
           <AuthButtons />
         </div>
-        <div className="pointer-events-none fixed inset-x-0 top-[-20%] -z-10 mx-auto h-[40rem] w-[40rem] rounded-full bg-gradient-to-br from-primary/30 via-primary/10 to-transparent blur-3xl opacity-60" aria-hidden="true" />
         <div className="relative mx-auto flex min-h-screen w-full max-w-7xl flex-col px-6 pb-16 pt-10 sm:px-10">
           <div className="animate-fade-in-up flex-1">{children}</div>
         </div>

--- a/app/my/[id]/page.jsx
+++ b/app/my/[id]/page.jsx
@@ -27,9 +27,8 @@ export default async function MyProjectDetailsPage({ params }) {
 
   return (
     <div className="space-y-12">
-      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/10 p-8 shadow-[0_34px_82px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
-        <div className="absolute inset-x-0 top-0 h-28 bg-[radial-gradient(circle_at_top,_rgba(245,245,245,0.14),_transparent_70%)]" aria-hidden="true" />
-        <div className="relative flex flex-wrap items-start justify-between gap-6">
+      <header className="rounded-[32px] border border-white/10 bg-neutral-900 p-8 shadow-[0_34px_82px_rgba(0,0,0,0.55)]">
+        <div className="flex flex-wrap items-start justify-between gap-6">
           <div className="space-y-3">
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-400">Your project</p>
             <h1 className="text-3xl font-semibold text-white">{submission.metadata?.projectTitle ?? submission.name}</h1>
@@ -45,11 +44,11 @@ export default async function MyProjectDetailsPage({ params }) {
       </header>
 
       <section className="grid gap-8 lg:grid-cols-[1.4fr_1fr]">
-        <article className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+        <article className="rounded-[28px] border border-white/10 bg-neutral-900 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)]">
           <h2 className="text-lg font-semibold text-white">Submission details</h2>
           <p className="mt-4 whitespace-pre-line leading-relaxed text-neutral-300/90">{submission.details}</p>
         </article>
-        <article className="space-y-4 rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+        <article className="space-y-4 rounded-[28px] border border-white/10 bg-neutral-900 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)]">
           <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-neutral-400">Project metadata</h3>
           <Meta label="Email" value={submission.email} />
           <Meta label="Timeline" value={submission.metadata?.timeline ?? '—'} />
@@ -60,7 +59,7 @@ export default async function MyProjectDetailsPage({ params }) {
         </article>
       </section>
 
-      <section className="rounded-[28px] border border-white/10 bg-white/10 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+      <section className="rounded-[28px] border border-white/10 bg-neutral-900 p-6 text-sm text-neutral-200/90 shadow-[0_28px_72px_rgba(0,0,0,0.55)]">
         <h2 className="text-lg font-semibold text-white">Reference links</h2>
         {Array.isArray(submission.metadata?.references) && submission.metadata.references.length ? (
           <ul className="mt-4 space-y-2">

--- a/app/review/page.jsx
+++ b/app/review/page.jsx
@@ -76,9 +76,8 @@ export default function ReviewPage() {
 
   return (
     <main className="space-y-10">
-      <header className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/10 p-8 shadow-[0_34px_82px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
-        <div className="absolute inset-x-0 top-0 h-28 bg-[radial-gradient(circle_at_top,_rgba(245,245,245,0.14),_transparent_70%)]" aria-hidden="true" />
-        <div className="relative space-y-4">
+      <header className="rounded-[32px] border border-white/10 bg-neutral-900 p-8 shadow-[0_34px_82px_rgba(0,0,0,0.55)]">
+        <div className="space-y-4">
           <span className="inline-flex items-center gap-2 rounded-full bg-primary/15 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-primary/80">
             Review Console
           </span>
@@ -94,7 +93,7 @@ export default function ReviewPage() {
         ) : error ? (
           <p className="text-sm text-neutral-300">{error}</p>
       ) : submissions.length === 0 ? (
-        <div className="rounded-[28px] border border-dashed border-white/15 bg-white/5 p-8 text-sm text-neutral-400">
+        <div className="rounded-[28px] border border-dashed border-white/20 bg-neutral-900 p-8 text-sm text-neutral-400">
           No submissions yet. Once requests are submitted, they will appear here for review.
         </div>
       ) : (
@@ -102,9 +101,8 @@ export default function ReviewPage() {
           {submissions.map((submission) => (
             <article
               key={submission.id}
-              className="group relative overflow-hidden rounded-[28px] border border-white/10 bg-white/10 p-6 shadow-[0_28px_72px_rgba(0,0,0,0.55)] transition duration-300 hover:border-white/20 hover:shadow-[0_36px_96px_rgba(0,0,0,0.62)]"
+              className="group overflow-hidden rounded-[28px] border border-white/10 bg-neutral-900 p-6 shadow-[0_28px_72px_rgba(0,0,0,0.55)] transition duration-300 hover:border-white/20 hover:shadow-[0_36px_96px_rgba(0,0,0,0.62)]"
             >
-              <div className="absolute right-6 top-6 h-10 w-10 rounded-full bg-white/10 blur-2xl opacity-0 transition duration-300 group-hover:opacity-100" aria-hidden="true" />
               <header className="relative flex flex-wrap items-start justify-between gap-4">
                 <div className="space-y-3">
                   <h2 className="text-lg font-semibold text-white">
@@ -125,7 +123,7 @@ export default function ReviewPage() {
                 {submission.metadata?.budget ? <p>Investment: {submission.metadata.budget}</p> : null}
                 {submission.metadata?.keyMoment ? <p>Key moment: {submission.metadata.keyMoment}</p> : null}
                 {Array.isArray(submission.metadata?.references) && submission.metadata.references.length ? (
-                  <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                  <div className="rounded-2xl border border-white/10 bg-black p-3">
                     <p className="text-xs font-semibold uppercase tracking-[0.24em] text-neutral-400">Reference links</p>
                     <ul className="mt-2 space-y-1 text-xs">
                       {submission.metadata.references.map((file, index) => (

--- a/components/IntakeForm.jsx
+++ b/components/IntakeForm.jsx
@@ -636,12 +636,29 @@ function Progress({ steps, current, onNavigate }) {
             type="button"
             onClick={() => onNavigate(index)}
             className={clsx(
-              'flex min-w-[140px] flex-col items-center rounded-2xl border px-4 py-2 transition',
-              isActive ? 'border-white/30 bg-white/10 text-white' : 'border-white/10 bg-transparent hover:border-white/20'
+              'flex min-w-[140px] flex-col items-center rounded-2xl border px-4 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60',
+              isActive
+                ? 'border-white bg-white text-neutral-900'
+                : 'border-white/40 bg-transparent text-white/70 hover:bg-white/10 hover:text-white'
             )}
+            aria-current={isActive ? 'step' : undefined}
           >
-            <span className="font-semibold uppercase tracking-[0.26em]">Step {index + 1}</span>
-            <span className="mt-1 text-[11px] tracking-wide text-white/60">{step.title}</span>
+            <span
+              className={clsx(
+                'font-semibold uppercase tracking-[0.26em] transition-colors',
+                isActive ? 'text-neutral-900' : 'text-white/70'
+              )}
+            >
+              Step {index + 1}
+            </span>
+            <span
+              className={clsx(
+                'mt-1 text-[11px] tracking-wide transition-colors',
+                isActive ? 'text-neutral-700' : 'text-white/50'
+              )}
+            >
+              {step.title}
+            </span>
           </button>
         )
       })}
@@ -660,11 +677,12 @@ function CheckboxGrid({ options, value, onChange }) {
             key={option}
             onClick={() => onChange(toggleValue(value, option))}
             className={clsx(
-              'flex items-start justify-start rounded-2xl border px-4 py-3 text-left text-sm transition shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30',
+              'flex items-start justify-start rounded-2xl border px-4 py-3 text-left text-sm transition shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70',
               checked
-                ? 'border-white/60 bg-white/15 text-white hover:border-white/70 hover:bg-white/20'
-                : 'border-white/10 bg-transparent text-white/70 hover:border-white/30 hover:bg-white/10 hover:text-white'
+                ? 'border-white bg-white text-neutral-900'
+                : 'border-white/40 bg-transparent text-white/80 hover:bg-white/10 hover:text-white'
             )}
+            aria-pressed={checked}
           >
             {option}
           </button>
@@ -685,11 +703,12 @@ function RadioGrid({ options, value, onChange }) {
             key={option}
             onClick={() => onChange(option)}
             className={clsx(
-              'flex items-start justify-start rounded-2xl border px-4 py-3 text-left text-sm transition shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30',
+              'flex items-start justify-start rounded-2xl border px-4 py-3 text-left text-sm transition shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70',
               checked
-                ? 'border-white/60 bg-white/15 text-white hover:border-white/70 hover:bg-white/20'
-                : 'border-white/10 bg-transparent text-white/70 hover:border-white/30 hover:bg-white/10 hover:text-white'
+                ? 'border-white bg-white text-neutral-900'
+                : 'border-white/40 bg-transparent text-white/80 hover:bg-white/10 hover:text-white'
             )}
+            aria-pressed={checked}
           >
             {option}
           </button>

--- a/components/ProjectTypeBadge.jsx
+++ b/components/ProjectTypeBadge.jsx
@@ -1,12 +1,12 @@
 import clsx from 'clsx'
 
 const typeConfig = {
-  design: 'from-white/18 via-white/8 to-transparent text-[#f5f5f5]',
-  development: 'from-white/16 via-white/6 to-transparent text-[#f5f5f5]',
-  research: 'from-white/14 via-white/6 to-transparent text-[#f5f5f5]',
-  content: 'from-white/18 via-white/8 to-transparent text-[#f5f5f5]',
-  'data-ml': 'from-white/14 via-white/6 to-transparent text-[#f5f5f5]',
-  other: 'from-white/12 via-white/5 to-transparent text-[#f5f5f5]'
+  design: 'border-white/40',
+  development: 'border-white/40',
+  research: 'border-white/40',
+  content: 'border-white/40',
+  'data-ml': 'border-white/40',
+  other: 'border-white/40'
 }
 
 export function ProjectTypeBadge({ type }) {
@@ -20,7 +20,7 @@ export function ProjectTypeBadge({ type }) {
   return (
     <span
       className={clsx(
-        'inline-flex items-center gap-1 rounded-full bg-gradient-to-br px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.26em] text-white/90 transition duration-200 backdrop-blur-md ring-1 ring-white/10',
+        'inline-flex items-center gap-1 rounded-full border bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.26em] text-neutral-900 transition duration-200',
         styles
       )}
     >


### PR DESCRIPTION
## Summary
- clarify the intake form stepper and option interactions so highlighting follows focus and selection more clearly
- replace gradient overlays across authenticated surfaces with a monochrome black and white treatment
- align shared components, including the project type badge, with the simplified palette

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dbb77067148333b34fb6d1fc52938a